### PR TITLE
Add CI workflows with Claude autofix integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "claude/**"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -1,0 +1,37 @@
+name: Claude CI Autofix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  autofix:
+    name: Auto-fix CI failures with Claude
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run Claude autofix
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: ""
+          autofix_on_ci_failure: "true"
+          branch: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
## Summary
This PR adds GitHub Actions workflows to enable continuous integration and automated code fixing for the repository.

## Key Changes
- **CI Workflow** (`ci.yml`): Implements a basic build and test pipeline that runs on pushes to `main` and `claude/**` branches, as well as pull requests to `main`. The workflow sets up Go, builds the project, and runs the test suite.

- **Claude Autofix Workflow** (`claude-autofix.yml`): Adds an automated code fixing workflow that triggers when the CI workflow fails. It uses the Claude Code Action to automatically attempt to fix CI failures and commit the changes back to the branch.

## Notable Implementation Details
- The autofix workflow is configured to run only on CI failures (`if: ${{ github.event.workflow_run.conclusion == 'failure' }}`)
- Both workflows use Go version from `go.mod` for consistency
- The autofix workflow has write permissions for contents and pull requests to enable automatic commits
- The autofix workflow targets the specific commit SHA and branch from the failed CI run
- The `claude/**` branch pattern allows for dedicated Claude-generated fix branches

https://claude.ai/code/session_01Y2rAthbcCcHqZ3TBEfZ8UX