### PR TITLE
feat: resolve 14 open issues across API, resilience, and discovery

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,6 +64,9 @@ func main() {
 	)
 
 	addr := ":8080"
+	if v := strings.TrimSpace(os.Getenv("LISTEN_ADDR")); v != "" {
+		addr = v
+	}
 	logger.Info("aggregator backend listening", "addr", addr)
 	srv := &http.Server{
 		Addr:              addr,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/angelospk/find_doctors_server/internal/aggregator"
 	"github.com/angelospk/find_doctors_server/internal/api"
@@ -10,22 +13,92 @@ import (
 )
 
 func main() {
-	log.Println("Initializing Ministry API Client...")
+	logger := newLogger()
+	slog.SetDefault(logger)
+
+	logger.Info("initializing ministry api client")
 	client := ministry.NewClient("https://www.finddoctors.gov.gr")
-	
-	log.Println("Initializing Concurrent Aggregator Engine...")
-	agg := aggregator.New(client)
-	
-	server := api.NewServer(agg)
+
+	logger.Info("initializing concurrent aggregator engine")
+	agg := aggregator.New(client).WithLogger(logger).WithDoctorClient(client)
+
+	server := api.NewServer(agg).WithLogger(logger)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/search", server.HandleSmartSearch)
-	mux.HandleFunc("/api/specialties", server.HandleGetSpecialties)
+	mux.HandleFunc("GET /healthz", server.HandleHealthz)
+	mux.HandleFunc("GET /readyz", server.HandleReadyz)
+
+	mux.HandleFunc("GET /api/search", server.HandleSmartSearch)
+	mux.HandleFunc("GET /api/specialties", server.HandleGetSpecialties)
+	mux.HandleFunc("GET /api/foreas", server.HandleHealthUnitTypes)
+	mux.HandleFunc("GET /api/prefectures", server.HandlePrefectures)
+	mux.HandleFunc("GET /api/prefectures/covid", server.HandleCovidPrefectures)
+	mux.HandleFunc("GET /api/prefectures/mental-health", server.HandleMentalHealthPrefectures)
+
+	mux.HandleFunc("GET /api/doctors/search", server.HandleDoctorSearch)
+	mux.HandleFunc("GET /api/doctors/nearby", server.HandleDoctorNearby)
+	mux.HandleFunc("GET /api/family-doctors/search", server.HandleFamilyDoctorSearch)
+	mux.HandleFunc("GET /api/covid/search", server.HandleCovidSearch)
+	mux.HandleFunc("GET /api/mental-health/search", server.HandleMentalHealthSearch)
+
+	mux.HandleFunc("GET /api/machines/types", server.HandleMachineRvTypes)
+	mux.HandleFunc("GET /api/machines/search", server.HandleMachineSearch)
+
 	mux.HandleFunc("GET /api/hospitals/{hunitId}/capacity", server.HandleHospitalCapacity)
 	mux.HandleFunc("GET /api/hospitals/{hunitId}/slots", server.HandleGranularSlots)
+	mux.HandleFunc("GET /api/hospitals/{hunitId}/doors", server.HandleClinicDoors)
 
-	log.Println("Aggregator backend server listening on http://localhost:8080")
-	if err := http.ListenAndServe(":8080", mux); err != nil {
-		log.Fatalf("Server failed to start: %v", err)
+	corsCfg := api.CORSConfig{
+		AllowedOrigins: corsOrigins(),
+		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders: []string{"Content-Type", "Authorization", "X-Request-Id"},
+		MaxAge:         600,
 	}
+
+	handler := api.Chain(mux,
+		api.RequestIDMiddleware,
+		api.RecoveryMiddleware(logger),
+		api.LoggingMiddleware(logger),
+		api.CORSMiddleware(corsCfg),
+		api.TimeoutMiddleware(30*time.Second),
+	)
+
+	addr := ":8080"
+	logger.Info("aggregator backend listening", "addr", addr)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
+		logger.Error("server failed to start", "error", err)
+		os.Exit(1)
+	}
+}
+
+func newLogger() *slog.Logger {
+	env := strings.ToLower(os.Getenv("APP_ENV"))
+	var h slog.Handler
+	if env == "" || env == "dev" || env == "development" {
+		h = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+	} else {
+		h = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	}
+	return slog.New(h)
+}
+
+func corsOrigins() []string {
+	raw := os.Getenv("CORS_ALLOWED_ORIGINS")
+	if raw == "" {
+		return []string{"*"}
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/internal/aggregator/capacity_test.go
+++ b/internal/aggregator/capacity_test.go
@@ -20,7 +20,7 @@ func TestHospitalCapacity_AllDisabled(t *testing.T) {
 
 	agg := New(mockClient)
 	specs := []ministry.Specialty{{ID: 6, Name: "Dermatologist"}}
-	
+
 	report, err := agg.HospitalCapacity(context.Background(), hId, 1, nil, specs)
 	if err != nil {
 		t.Fatalf("HospitalCapacity failed: %v", err)
@@ -34,8 +34,14 @@ func TestHospitalCapacity_AllDisabled(t *testing.T) {
 		t.Fatalf("Expected 1 specialty report, got %d", len(report.Specialties))
 	}
 
-	if report.Specialties[0].FillRate != 100.0 {
-		t.Errorf("Expected 100.0 fillRate, got %.1f", report.Specialties[0].FillRate)
+	// After #16 fix: every group on the only known day is disabled, which means
+	// the doctor isn't on schedule that day — not that the day is fully booked.
+	// Old behavior returned 100%; new behavior returns 0 with empty scheduleDays.
+	if report.Specialties[0].FillRate != 0.0 {
+		t.Errorf("Expected 0.0 fillRate for fully-disabled schedule, got %.1f", report.Specialties[0].FillRate)
+	}
+	if len(report.Specialties[0].ScheduleDays) != 0 {
+		t.Errorf("Expected empty scheduleDays, got %v", report.Specialties[0].ScheduleDays)
 	}
 }
 
@@ -53,11 +59,54 @@ func TestHospitalCapacity_MixedSlots(t *testing.T) {
 
 	agg := New(mockClient)
 	specs := []ministry.Specialty{{ID: 6, Name: "Dermatologist"}}
-	
-	report, _ := agg.HospitalCapacity(context.Background(), 21, 1, nil, specs)
-	
-	// 2 disabled out of 4 total = 50%
+
+	report, err := agg.HospitalCapacity(context.Background(), 21, 1, nil, specs)
+	if err != nil {
+		t.Fatalf("HospitalCapacity failed: %v", err)
+	}
+
+	// All groups land on Day=0; 2 of 4 are disabled → 50% on an active day.
 	if report.Specialties[0].FillRate != 50.0 {
 		t.Errorf("Expected 50.0 fillRate, got %.1f", report.Specialties[0].FillRate)
+	}
+}
+
+func TestHospitalCapacity_LimitedSchedule_DoesNotInflateFillRate(t *testing.T) {
+	// Regression for #16: the doctor only works Monday and Wednesday.
+	// The API returns disabled groups for every other day. Under the old
+	// algorithm those days inflated fillRate to ~83%. The new per-day rule
+	// should exclude fully-disabled days entirely and report ~33% (1 disabled
+	// out of 3 active groups across Mon+Wed), with scheduleDays=[1,3].
+	mockClient := &MockMinistryClient{
+		GetSlotsInitFunc: func(ctx context.Context, payload ministry.SlotsInitPayload) ([]ministry.SlotGroup, error) {
+			return []ministry.SlotGroup{
+				// Monday: 1 active, 1 disabled (partially booked)
+				{Day: 1, GroupColor: "available"},
+				{Day: 1, GroupColor: "disabled"},
+				// Tuesday: doctor doesn't work
+				{Day: 2, GroupColor: "disabled"},
+				{Day: 2, GroupColor: "disabled"},
+				// Wednesday: 1 active
+				{Day: 3, GroupColor: "available"},
+				// Thursday: doctor doesn't work
+				{Day: 4, GroupColor: "disabled"},
+				{Day: 4, GroupColor: "disabled"},
+			}, nil
+		},
+	}
+
+	agg := New(mockClient)
+	specs := []ministry.Specialty{{ID: 6, Name: "Cardiology"}}
+	report, err := agg.HospitalCapacity(context.Background(), 21, 1, nil, specs)
+	if err != nil {
+		t.Fatalf("HospitalCapacity failed: %v", err)
+	}
+
+	s := report.Specialties[0]
+	if s.FillRate < 33.0 || s.FillRate > 34.0 {
+		t.Errorf("Expected ~33%% fillRate, got %.2f", s.FillRate)
+	}
+	if len(s.ScheduleDays) != 2 || s.ScheduleDays[0] != 1 || s.ScheduleDays[1] != 3 {
+		t.Errorf("Expected scheduleDays=[1,3], got %v", s.ScheduleDays)
 	}
 }

--- a/internal/aggregator/ready_test.go
+++ b/internal/aggregator/ready_test.go
@@ -1,0 +1,67 @@
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/angelospk/find_doctors_server/internal/ministry"
+)
+
+// pingMock implements MinistryClient plus the optional Ping capability so the
+// readiness check exercises the cache-bypassing path.
+type pingMock struct {
+	MockMinistryClient
+	pingErr    error
+	pingCalled bool
+	specCalled bool
+}
+
+func (m *pingMock) Ping(ctx context.Context) error {
+	m.pingCalled = true
+	return m.pingErr
+}
+
+func (m *pingMock) GetSpecialties(ctx context.Context) ([]ministry.Specialty, error) {
+	m.specCalled = true
+	return nil, nil
+}
+
+func TestReady_UsesPingAndBypassesCache(t *testing.T) {
+	m := &pingMock{}
+	agg := New(m)
+	if err := agg.Ready(context.Background()); err != nil {
+		t.Fatalf("expected ready, got %v", err)
+	}
+	if !m.pingCalled {
+		t.Error("expected Ping to be used for readiness")
+	}
+	if m.specCalled {
+		t.Error("readiness must not rely on cached GetSpecialties")
+	}
+}
+
+func TestReady_PropagatesPingFailure(t *testing.T) {
+	m := &pingMock{pingErr: errors.New("upstream down")}
+	agg := New(m)
+	if err := agg.Ready(context.Background()); err == nil {
+		t.Fatal("expected readiness failure when upstream ping fails")
+	}
+}
+
+func TestReady_FallsBackWhenNoPing(t *testing.T) {
+	called := false
+	m := &MockMinistryClient{
+		GetSpecialtiesFunc: func(ctx context.Context) ([]ministry.Specialty, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	agg := New(m)
+	if err := agg.Ready(context.Background()); err != nil {
+		t.Fatalf("expected ready, got %v", err)
+	}
+	if !called {
+		t.Error("expected GetSpecialties fallback when client lacks Ping")
+	}
+}

--- a/internal/aggregator/search.go
+++ b/internal/aggregator/search.go
@@ -3,8 +3,10 @@ package aggregator
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,61 +22,146 @@ type MinistryClient interface {
 	GetActualSlots(ctx context.Context, payload ministry.GetActualSlotsPayload) ([]ministry.ActualSlot, error)
 }
 
+// DoctorClient is the optional doctor-search interface; only the real *ministry.Client
+// implements it. Tests can leave it nil to skip doctor-search exercises.
+type DoctorClient interface {
+	SearchDoctors(ctx context.Context, payload ministry.SearchDoctorsPayload) ([]ministry.Doctor, error)
+	SearchDoctorsByLocation(ctx context.Context, payload ministry.SearchDoctorsPayload) ([]ministry.Doctor, error)
+	SearchDoctorsFD(ctx context.Context, payload ministry.SearchDoctorsPayload) ([]ministry.Doctor, error)
+	SearchHunitsFD(ctx context.Context, payload ministry.SearchPayload) ([]ministry.HUnit, error)
+	GetHealthUnitTypes(ctx context.Context) ([]ministry.HealthUnitType, error)
+	GetPrefectures(ctx context.Context) ([]ministry.Prefecture, error)
+	GetCovidPrefectures(ctx context.Context) ([]ministry.Prefecture, error)
+	GetMentalHealthPrefectures(ctx context.Context) ([]ministry.Prefecture, error)
+	GetClinicDoors(ctx context.Context, hunitID, specialtyID int) ([]ministry.ClinicDoor, error)
+	GetMachineRvTypes(ctx context.Context) ([]ministry.MachineRvType, error)
+	SearchHunitsMachines(ctx context.Context, payload ministry.SearchPayload) ([]ministry.HUnit, error)
+}
+
 // Aggregator coordinates concurrent searches across different entities.
 type Aggregator struct {
 	client     MinistryClient
+	docClient  DoctorClient // optional, may be nil
+	logger     *slog.Logger
 	specCache  []ministry.Specialty
 	specMu     sync.RWMutex
 	lastSpecUp time.Time
+
+	// foreasIDsCache + expiry for dynamic foreas discovery (#17).
+	foreasMu      sync.RWMutex
+	foreasCache   []int
+	foreasExpires time.Time
+
+	// Default fallback when dynamic discovery is unavailable.
+	defaultForeasIDs []int
 }
 
-// New creates a new Aggregator instance.
+// New creates a new Aggregator instance using a discard logger by default.
 func New(client MinistryClient) *Aggregator {
-	return &Aggregator{client: client}
+	return &Aggregator{
+		client:           client,
+		logger:           slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		defaultForeasIDs: []int{1, 18},
+	}
 }
 
-// SearchUnified runs searches across Hospitals (1) and PFY (18) concurrently and merges results.
+// WithLogger attaches a structured logger and returns the aggregator for chaining.
+func (a *Aggregator) WithLogger(l *slog.Logger) *Aggregator {
+	if l != nil {
+		a.logger = l
+	}
+	return a
+}
+
+// WithDoctorClient attaches the extended client used for doctor-search and discovery flows.
+func (a *Aggregator) WithDoctorClient(c DoctorClient) *Aggregator {
+	a.docClient = c
+	return a
+}
+
+// DoctorClient returns the extended client, or nil if unset.
+func (a *Aggregator) DoctorClient() DoctorClient { return a.docClient }
+
+// Client exposes the underlying ministry client for handlers that need raw access
+// (e.g. COVID / Mental Health flag passthrough).
+func (a *Aggregator) Client() MinistryClient { return a.client }
+
+// SearchUnified runs searches across active foreas types concurrently and merges results.
 func (a *Aggregator) SearchUnified(ctx context.Context, payload ministry.SearchPayload) ([]ministry.HUnit, error) {
+	foreasIDs := a.activeForeasIDs(ctx, []int{1, 18})
+
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	allUnits := []ministry.HUnit{}
 	var errs []error
 
-	foreasIDs := []int{1, 18}
-
 	for _, fID := range foreasIDs {
 		wg.Add(1)
-		// Launch a goroutine for each foreasID
 		go func(id int) {
 			defer wg.Done()
-			
-			// Copy the payload and inject the specific ForeasID
+
 			p := payload
 			p.ForeasID = id
-			
+
 			units, err := a.client.SearchHUnits(ctx, p)
 
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
-				fmt.Printf("Error searching Foreas %d: %v\n", id, err)
+				a.logger.Warn("foreas search failed", "foreas_id", id, "error", err)
 				errs = append(errs, err)
 				return
 			}
-			fmt.Printf("Found %d units for Foreas %d\n", len(units), id)
+			a.logger.Debug("foreas search result", "foreas_id", id, "count", len(units))
 			allUnits = append(allUnits, units...)
 		}(fID)
 	}
 
 	wg.Wait()
-	fmt.Printf("Total units found after merge: %d\n", len(allUnits))
+	a.logger.Debug("unified search merge", "total", len(allUnits))
 
-	// If all requests failed, return the first error
 	if len(errs) == len(foreasIDs) {
 		return nil, errs[0]
 	}
-
 	return allUnits, nil
+}
+
+// activeForeasIDs returns the foreas list to use for unit-flavored searches.
+// If a DoctorClient is wired in, it pulls the live catalog and caches it 24h.
+// Falls back to `fallback` on any error so production stays green.
+func (a *Aggregator) activeForeasIDs(ctx context.Context, fallback []int) []int {
+	if a.docClient == nil {
+		return fallback
+	}
+	a.foreasMu.RLock()
+	if time.Now().Before(a.foreasExpires) && len(a.foreasCache) > 0 {
+		ids := a.foreasCache
+		a.foreasMu.RUnlock()
+		return ids
+	}
+	a.foreasMu.RUnlock()
+
+	types, err := a.docClient.GetHealthUnitTypes(ctx)
+	if err != nil || len(types) == 0 {
+		a.logger.Warn("health unit types fetch failed, using fallback", "error", err)
+		return fallback
+	}
+	// Only consider unit-typed foreas (1, 18) for /searchhunits. 19 and 20 are
+	// for doctor-flavored endpoints — leave them out of the default unit search.
+	out := make([]int, 0, len(types))
+	for _, t := range types {
+		if t.HUnitType == 1 || t.HUnitType == 18 {
+			out = append(out, t.HUnitType)
+		}
+	}
+	if len(out) == 0 {
+		out = fallback
+	}
+	a.foreasMu.Lock()
+	a.foreasCache = out
+	a.foreasExpires = time.Now().Add(24 * time.Hour)
+	a.foreasMu.Unlock()
+	return out
 }
 
 // ScannedUnit represents a health unit with its earliest available appointment date.
@@ -85,17 +172,14 @@ type ScannedUnit struct {
 }
 
 // FastScanner concurrently checks the first available slot for a list of units.
-// It uses a semaphore pattern to prevent overwhelming the upstream API.
 func (a *Aggregator) FastScanner(ctx context.Context, units []ministry.HUnit, payload ministry.SearchPayload) []ScannedUnit {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	results := []ScannedUnit{}
 
-	// Limit concurrent requests to 20
 	sem := make(chan struct{}, 20)
 
 	for _, u := range units {
-		// Only check if we have a valid unit ID
 		if u.HUnit == nil {
 			continue
 		}
@@ -103,9 +187,9 @@ func (a *Aggregator) FastScanner(ctx context.Context, units []ministry.HUnit, pa
 		wg.Add(1)
 		go func(unit ministry.HUnit) {
 			defer wg.Done()
-			
-			sem <- struct{}{}        // Acquire token
-			defer func() { <-sem }() // Release token
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
 
 			p := payload
 			p.HUnit = unit.HUnit
@@ -117,7 +201,7 @@ func (a *Aggregator) FastScanner(ctx context.Context, units []ministry.HUnit, pa
 				datePtr = &dateStr
 			}
 
-			fmt.Printf("Unit %d (%s) result: %v\n", *unit.HUnit, unit.Name, datePtr)
+			a.logger.Debug("first slot probe", "hunit", *unit.HUnit, "name", unit.Name, "date", datePtr)
 			mu.Lock()
 			results = append(results, ScannedUnit{
 				HUnit:     unit,
@@ -139,12 +223,9 @@ type SmartSearchOptions struct {
 }
 
 // SmartSearch combines availability scanning with geographic filtering and multi-level sorting.
-// It prioritizes "Soonest" (Date) then "Closest" (Distance) within a specific radius.
 func (a *Aggregator) SmartSearch(ctx context.Context, units []ministry.HUnit, payload ministry.SearchPayload, opts SmartSearchOptions) []ScannedUnit {
-	// 1. Scan availability for all candidates
 	scanned := a.FastScanner(ctx, units, payload)
 
-	// 2. Filter by distance if coordinates and max distance provided
 	var filtered []ScannedUnit
 	if opts.MaxDistance > 0 && opts.Lat != nil && opts.Lon != nil {
 		for _, u := range scanned {
@@ -157,11 +238,7 @@ func (a *Aggregator) SmartSearch(ctx context.Context, units []ministry.HUnit, pa
 		filtered = scanned
 	}
 
-	// 3. Multi-level Sorting:
-	// Primary: FirstAvailableDate ASC
-	// Secondary: Distance from user ASC
 	sort.Slice(filtered, func(i, j int) bool {
-		// Handle nil dates: push to the end
 		if filtered[i].FirstDate == nil && filtered[j].FirstDate == nil {
 			return false
 		}
@@ -171,11 +248,9 @@ func (a *Aggregator) SmartSearch(ctx context.Context, units []ministry.HUnit, pa
 		if filtered[j].FirstDate == nil {
 			return true
 		}
-
 		if *filtered[i].FirstDate != *filtered[j].FirstDate {
 			return *filtered[i].FirstDate < *filtered[j].FirstDate
 		}
-		// Sub-sort by distance if coordinates are available
 		if opts.Lat != nil && opts.Lon != nil {
 			distI := distance(*opts.Lat, *opts.Lon, filtered[i].Latitude, filtered[i].Longitude)
 			distJ := distance(*opts.Lat, *opts.Lon, filtered[j].Latitude, filtered[j].Longitude)
@@ -202,11 +277,18 @@ type GranularSlot struct {
 	RVTName   string `json:"rvtName"`
 }
 
+// GranularSlotsOptions controls optional filters for GetGranularSlots.
+type GranularSlotsOptions struct {
+	CDoorID *int
+	// TimeOfDay restricts to one of: "morning" (06-09), "noon" (09-12), "afternoon" (12-15).
+	// Empty string means no filter.
+	TimeOfDay string
+}
+
 // GetGranularSlots fetches and flattens all available appointment times for a unit on a given date.
-func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int, prefID *int, specialtyID int, date string) ([]GranularSlot, error) {
+func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int, prefID *int, specialtyID int, date string, opts GranularSlotsOptions) ([]GranularSlot, error) {
 	parsedDate, err := time.Parse(time.RFC3339, date)
 	if err != nil {
-		// Try simple date format
 		parsedDate, err = time.Parse("2006-01-02", date)
 		if err != nil {
 			return nil, fmt.Errorf("invalid date format: %w", err)
@@ -216,7 +298,6 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 	startDay := parsedDate.Truncate(24 * time.Hour)
 	endDay := startDay.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
 
-	// 1. Get capacity chunks (groups) for the day
 	payload := ministry.SlotsInitPayload{
 		StartDate:    startDay.Format("2006-01-02T15:04:05.000Z"),
 		EndDate:      endDay.Format("2006-01-02T15:04:05.000Z"),
@@ -224,6 +305,7 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 		PrefectureID: prefID,
 		HUnit:        &hunitID,
 		ForeasID:     foreasID,
+		CDoorID:      opts.CDoorID,
 		IsCovid:      0,
 		IsOnlyFd:     0,
 		IsMachine:    0,
@@ -234,7 +316,6 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 		return nil, err
 	}
 
-	// 2. Concurrently fetch actual slots for each group that has capacity
 	type result struct {
 		groupID int
 		slots   []ministry.ActualSlot
@@ -245,12 +326,9 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 	var wg sync.WaitGroup
 
 	for _, g := range groups {
-		// 1. Filter by requested day (only if API provides it, e.g. for PFY 7-day calendars)
 		if g.Day > 0 && g.Day != int(parsedDate.Weekday()) {
 			continue
 		}
-
-		// 2. Skip empty or invalid groups
 		if g.GroupColor == "" || g.GroupColor == "disabled" {
 			continue
 		}
@@ -259,8 +337,7 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 		wg.Add(1)
 		go func(groupID int) {
 			defer wg.Done()
-			
-			// Prefecture ID is required for getactualslots or it returns []
+
 			pID := 0
 			if prefID != nil {
 				pID = *prefID
@@ -276,7 +353,7 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 				PrefectureID: pID,
 				IsOnlyFd:     0,
 				IsMachine:    0,
-				CDoorID:      nil,
+				CDoorID:      opts.CDoorID,
 			}
 			slots, err := a.client.GetActualSlots(ctx, p)
 			resChan <- result{groupID: groupID, slots: slots, err: err}
@@ -286,16 +363,15 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 	wg.Wait()
 	close(resChan)
 
-	// 3. Flatten and unify results
 	var allSlots []GranularSlot
 	for r := range resChan {
 		if r.err != nil {
-			log.Printf("Warning: failed to fetch actual slots for group %d: %v", r.groupID, r.err)
+			a.logger.Warn("actual slots fetch failed", "group_id", r.groupID, "error", r.err)
 			continue
 		}
 
 		for _, s := range r.slots {
-			allSlots = append(allSlots, GranularSlot{
+			gs := GranularSlot{
 				HUnitID:   s.HUnitID,
 				Time:      s.RVTime,
 				Date:      s.RVDate,
@@ -306,16 +382,46 @@ func (a *Aggregator) GetGranularSlots(ctx context.Context, hunitID, foreasID int
 				GroupID:   r.groupID,
 				Comments:  fmt.Sprintf("%s %s", deref(s.Comments), deref(s.Comments2)),
 				RVTName:   s.RVTName,
-			})
+			}
+			if !slotInTimeWindow(gs.Time, opts.TimeOfDay) {
+				continue
+			}
+			allSlots = append(allSlots, gs)
 		}
 	}
 
-	// 4. Sort by time
 	sort.Slice(allSlots, func(i, j int) bool {
 		return allSlots[i].Time < allSlots[j].Time
 	})
 
 	return allSlots, nil
+}
+
+// slotInTimeWindow returns true when t falls in the requested band, or when no
+// band is configured. Time strings are H:MM, HH:MM, or HH:MM:SS in 24-hour form.
+func slotInTimeWindow(t, band string) bool {
+	if band == "" {
+		return true
+	}
+	colon := strings.IndexByte(t, ':')
+	if colon <= 0 {
+		return false
+	}
+	h, err := strconv.Atoi(t[:colon])
+	if err != nil {
+		return false
+	}
+	switch band {
+	case "morning":
+		return h >= 6 && h < 9
+	case "noon":
+		return h >= 9 && h < 12
+	case "afternoon":
+		return h >= 12 && h < 15
+	default:
+		// Unknown band → don't filter (caller is responsible for validating).
+		return true
+	}
 }
 
 func deref(s *string) string {
@@ -328,10 +434,13 @@ func deref(s *string) string {
 // SpecialtyCapacity represents the calculated fill-rate for a single specialty.
 // tygo:generate
 type SpecialtyCapacity struct {
-	ID        int     `json:"specialtyId"`
-	Name      string  `json:"name"`
-	FillRate  float64 `json:"fillRate"`  // Percentage of "disabled" slots
-	FirstDate *string `json:"firstDate"` // Earliest available slot
+	ID            int     `json:"specialtyId"`
+	Name          string  `json:"name"`
+	FillRate      float64 `json:"fillRate"`
+	FirstDate     *string `json:"firstDate"`
+	ScheduleDays  []int   `json:"scheduleDays"`
+	ActiveGroups  int     `json:"activeGroups"`
+	DisabledSlots int     `json:"disabledSlots"`
 }
 
 // CapacityReport represents the overall capacity for a medical unit.
@@ -343,10 +452,8 @@ type CapacityReport struct {
 }
 
 // HospitalCapacity aggregates capacity across all specialties for a unit.
-// Window is hardcoded to the current week (Monday to Sunday).
 func (a *Aggregator) HospitalCapacity(ctx context.Context, hunitID, foreasID int, prefID *int, specialties []ministry.Specialty) (CapacityReport, error) {
 	now := time.Now().UTC()
-	// Next Monday to next Sunday
 	offset := 8 - int(now.Weekday())
 	if offset > 7 {
 		offset = 1
@@ -369,7 +476,7 @@ func (a *Aggregator) HospitalCapacity(ctx context.Context, hunitID, foreasID int
 	}
 
 	resChan := make(chan result, len(specialties))
-	sem := make(chan struct{}, 30) // Semaphore cap
+	sem := make(chan struct{}, 30)
 
 	var wg sync.WaitGroup
 	for _, spec := range specialties {
@@ -397,7 +504,6 @@ func (a *Aggregator) HospitalCapacity(ctx context.Context, hunitID, foreasID int
 				return
 			}
 
-			// Also fetch the first available slot date for this specialty to make the heatmap actionable
 			searchPayload := ministry.SearchPayload{
 				StartDate:    startStr,
 				EndDate:      time.Now().AddDate(0, 6, 0).UTC().Format("2006-01-02T15:04:05.000Z"),
@@ -408,75 +514,28 @@ func (a *Aggregator) HospitalCapacity(ctx context.Context, hunitID, foreasID int
 			}
 			firstDate, err := a.client.FirstAvailableSlot(ctx, searchPayload)
 			if err != nil {
-				log.Printf("Warning: failed to check first slot for unit %d specialty %d: %v", hunitID, s.ID, err)
+				a.logger.Warn("first slot probe failed", "hunit", hunitID, "specialty", s.ID, "error", err)
 			}
 			var datePtr *string
 			if len(firstDate) == 10 {
 				datePtr = &firstDate
 			}
 
-			if len(groups) == 0 {
-				resChan <- result{
-					spec: s,
-					cap: SpecialtyCapacity{
-						ID:        s.ID,
-						Name:      s.Name,
-						FillRate:  0.0,
-						FirstDate: datePtr,
-					},
-				}
+			capRow := SpecialtyCapacity{
+				ID:        s.ID,
+				Name:      s.Name,
+				FirstDate: datePtr,
+			}
+
+			if len(groups) == 0 || (len(groups) == 1 && groups[0].ResponseCode == 2) {
+				capRow.FillRate = 0.0
+				capRow.ScheduleDays = []int{}
+				resChan <- result{spec: s, cap: capRow}
 				return
 			}
 
-			// Handle responseCode: 2 (No appointments found)
-			if len(groups) == 1 && groups[0].ResponseCode == 2 {
-				resChan <- result{
-					spec: s,
-					cap: SpecialtyCapacity{
-						ID:        s.ID,
-						Name:      s.Name,
-						FillRate:  0.0, // Treat as available (0% full)
-						FirstDate: datePtr,
-					},
-				}
-				return
-			}
-
-			disabled := 0
-			total := 0
-			for _, g := range groups {
-				if g.GroupColor == "" {
-					continue // Meta info / error object
-				}
-				total++
-				if g.GroupColor == "disabled" {
-					disabled++
-				}
-			}
-
-			if total == 0 {
-				resChan <- result{
-					spec: s,
-					cap: SpecialtyCapacity{
-						ID:        s.ID,
-						Name:      s.Name,
-						FillRate:  0.0,
-						FirstDate: datePtr,
-					},
-				}
-				return
-			}
-
-			fillRate := (float64(disabled) / float64(total)) * 100.0
-			resChan <- result{
-				spec: s,
-				cap: SpecialtyCapacity{
-					ID:        s.ID,
-					Name:      s.Name,
-					FillRate:  fillRate,
-					FirstDate: datePtr,
-				},
-			}
+			capRow = computeFillRate(capRow, groups)
+			resChan <- result{spec: s, cap: capRow}
 		}(spec)
 	}
 
@@ -485,7 +544,7 @@ func (a *Aggregator) HospitalCapacity(ctx context.Context, hunitID, foreasID int
 
 	for r := range resChan {
 		if r.err != nil {
-			log.Printf("Error scanning specialty %s (%d): %v", r.spec.Name, r.spec.ID, r.err)
+			a.logger.Warn("specialty scan failed", "specialty", r.spec.Name, "id", r.spec.ID, "error", r.err)
 			continue
 		}
 		if r.cap.ID != 0 {
@@ -494,13 +553,65 @@ func (a *Aggregator) HospitalCapacity(ctx context.Context, hunitID, foreasID int
 	}
 
 	report.Scanned = len(report.Specialties)
-	
-	// Sort by fill rate descending
+
 	sort.Slice(report.Specialties, func(i, j int) bool {
 		return report.Specialties[i].FillRate > report.Specialties[j].FillRate
 	})
 
 	return report, nil
+}
+
+// computeFillRate implements the #16 fix: per-day grouping with fully-disabled
+// days excluded from the denominator, plus an explicit scheduleDays list.
+func computeFillRate(row SpecialtyCapacity, groups []ministry.SlotGroup) SpecialtyCapacity {
+	type dayStats struct {
+		total    int
+		disabled int
+	}
+	perDay := make(map[int]*dayStats)
+
+	for _, g := range groups {
+		if g.GroupColor == "" {
+			continue
+		}
+		d, ok := perDay[g.Day]
+		if !ok {
+			d = &dayStats{}
+			perDay[g.Day] = d
+		}
+		d.total++
+		if g.GroupColor == "disabled" {
+			d.disabled++
+		}
+	}
+
+	// Active days are those with at least one non-disabled group.
+	activeDays := make([]int, 0, len(perDay))
+	activeGroups := 0
+	disabledInActive := 0
+	for day, s := range perDay {
+		if s.total == 0 {
+			continue
+		}
+		if s.disabled == s.total {
+			// Day is entirely off — not part of the schedule.
+			continue
+		}
+		activeDays = append(activeDays, day)
+		activeGroups += s.total
+		disabledInActive += s.disabled
+	}
+	sort.Ints(activeDays)
+
+	row.ScheduleDays = activeDays
+	row.ActiveGroups = activeGroups
+	row.DisabledSlots = disabledInActive
+	if activeGroups == 0 {
+		row.FillRate = 0.0
+	} else {
+		row.FillRate = (float64(disabledInActive) / float64(activeGroups)) * 100.0
+	}
+	return row
 }
 
 // GetSpecialties returns a cached list of specialties.
@@ -515,7 +626,6 @@ func (a *Aggregator) GetSpecialties(ctx context.Context) ([]ministry.Specialty, 
 	a.specMu.Lock()
 	defer a.specMu.Unlock()
 
-	// Double-check after lock
 	if time.Since(a.lastSpecUp) < 1*time.Hour && len(a.specCache) > 0 {
 		return a.specCache, nil
 	}
@@ -529,3 +639,8 @@ func (a *Aggregator) GetSpecialties(ctx context.Context) ([]ministry.Specialty, 
 	a.lastSpecUp = time.Now()
 	return specs, nil
 }
+
+// discardWriter is a minimal io.Writer that drops everything (used as a slog default sink).
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/aggregator/search.go
+++ b/internal/aggregator/search.go
@@ -86,6 +86,24 @@ func (a *Aggregator) DoctorClient() DoctorClient { return a.docClient }
 // (e.g. COVID / Mental Health flag passthrough).
 func (a *Aggregator) Client() MinistryClient { return a.client }
 
+// pinger is implemented by clients that can perform a cheap, cache-bypassing
+// upstream reachability check (the real *ministry.Client does).
+type pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// Ready performs a live upstream reachability check for readiness probes.
+// It bypasses the 24h specialties cache when the client supports Ping, so a
+// stale cache cannot keep readiness green during an upstream outage. Clients
+// without Ping fall back to GetSpecialties.
+func (a *Aggregator) Ready(ctx context.Context) error {
+	if p, ok := a.client.(pinger); ok {
+		return p.Ping(ctx)
+	}
+	_, err := a.client.GetSpecialties(ctx)
+	return err
+}
+
 // SearchUnified runs searches across active foreas types concurrently and merges results.
 func (a *Aggregator) SearchUnified(ctx context.Context, payload ministry.SearchPayload) ([]ministry.HUnit, error) {
 	foreasIDs := a.activeForeasIDs(ctx, []int{1, 18})

--- a/internal/aggregator/search_test.go
+++ b/internal/aggregator/search_test.go
@@ -184,9 +184,9 @@ func TestAggregator_SmartSearch(t *testing.T) {
 	h3 := 300
 
 	units := []ministry.HUnit{
-		{HUnit: &h1, Name: "Close Soon", Latitude: 37.98, Longitude: 23.72, ForeasID: 1},      // ~0km
-		{HUnit: &h2, Name: "Far Soon", Latitude: 38.24, Longitude: 21.73, ForeasID: 1},       // ~170km (Patras)
-		{HUnit: &h3, Name: "Close Late", Latitude: 37.97, Longitude: 23.73, ForeasID: 1},      // ~1km
+		{HUnit: &h1, Name: "Close Soon", Latitude: 37.98, Longitude: 23.72, ForeasID: 1}, // ~0km
+		{HUnit: &h2, Name: "Far Soon", Latitude: 38.24, Longitude: 21.73, ForeasID: 1},   // ~170km (Patras)
+		{HUnit: &h3, Name: "Close Late", Latitude: 37.97, Longitude: 23.73, ForeasID: 1}, // ~1km
 	}
 
 	mockClient := &MockMinistryClient{
@@ -228,7 +228,7 @@ func TestAggregator_SmartSearch(t *testing.T) {
 			MaxDistance: 0, // No limit
 		}
 		results := agg.SmartSearch(ctx, units, ministry.SearchPayload{}, opts)
-		
+
 		if len(results) != 3 {
 			t.Fatalf("Expected 3 results, got %d", len(results))
 		}
@@ -356,15 +356,15 @@ func TestAggregator_GetGranularSlots_WithComments(t *testing.T) {
 			if payload.GroupID == 1 {
 				return []ministry.ActualSlot{
 					{
-						HUnitID: 123,
-						RVDate:  "2026-03-23T08:30:00.000+0200",
-						RVTime:  "08:30",
-						DocName: "Dr. Commentator",
-						Address: "123 Comment St",
-						City:    "Literal City",
-						Comments: func(s string) *string { return &s }("Requires medical record."),
+						HUnitID:   123,
+						RVDate:    "2026-03-23T08:30:00.000+0200",
+						RVTime:    "08:30",
+						DocName:   "Dr. Commentator",
+						Address:   "123 Comment St",
+						City:      "Literal City",
+						Comments:  func(s string) *string { return &s }("Requires medical record."),
 						Comments2: func(s string) *string { return &s }("Please arrive 15m early."),
-						RVTName: "Specialized",
+						RVTName:   "Specialized",
 					},
 				}, nil
 			}

--- a/internal/aggregator/search_test.go
+++ b/internal/aggregator/search_test.go
@@ -320,7 +320,7 @@ func TestAggregator_GetGranularSlots(t *testing.T) {
 	agg := New(mockClient)
 	ctx := context.Background()
 
-	slots, err := agg.GetGranularSlots(ctx, hUnitID, foreasID, nil, specID, date)
+	slots, err := agg.GetGranularSlots(ctx, hUnitID, foreasID, nil, specID, date, GranularSlotsOptions{})
 	if err != nil {
 		t.Fatalf("GetGranularSlots failed: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestAggregator_GetGranularSlots_WithComments(t *testing.T) {
 	ctx := context.Background()
 
 	// Monday, 2026-03-23
-	slots, err := agg.GetGranularSlots(ctx, 123, 1, nil, 1, "2026-03-23")
+	slots, err := agg.GetGranularSlots(ctx, 123, 1, nil, 1, "2026-03-23", GranularSlotsOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get slots: %v", err)
 	}

--- a/internal/api/doctor_search_test.go
+++ b/internal/api/doctor_search_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/angelospk/find_doctors_server/internal/aggregator"
+	"github.com/angelospk/find_doctors_server/internal/ministry"
+)
+
+// stubDoctorClient captures the payloads passed to doctor-search methods so
+// tests can assert StartDate/EndDate are populated.
+type stubDoctorClient struct {
+	lastSearch ministry.SearchDoctorsPayload
+}
+
+func (s *stubDoctorClient) SearchDoctors(_ context.Context, p ministry.SearchDoctorsPayload) ([]ministry.Doctor, error) {
+	s.lastSearch = p
+	return []ministry.Doctor{}, nil
+}
+
+func (s *stubDoctorClient) SearchDoctorsByLocation(_ context.Context, p ministry.SearchDoctorsPayload) ([]ministry.Doctor, error) {
+	s.lastSearch = p
+	return []ministry.Doctor{}, nil
+}
+
+func (s *stubDoctorClient) SearchDoctorsFD(_ context.Context, p ministry.SearchDoctorsPayload) ([]ministry.Doctor, error) {
+	s.lastSearch = p
+	return []ministry.Doctor{}, nil
+}
+
+func (s *stubDoctorClient) SearchHunitsFD(context.Context, ministry.SearchPayload) ([]ministry.HUnit, error) {
+	return []ministry.HUnit{}, nil
+}
+func (s *stubDoctorClient) GetHealthUnitTypes(context.Context) ([]ministry.HealthUnitType, error) {
+	return nil, nil
+}
+func (s *stubDoctorClient) GetPrefectures(context.Context) ([]ministry.Prefecture, error) {
+	return nil, nil
+}
+func (s *stubDoctorClient) GetCovidPrefectures(context.Context) ([]ministry.Prefecture, error) {
+	return nil, nil
+}
+func (s *stubDoctorClient) GetMentalHealthPrefectures(context.Context) ([]ministry.Prefecture, error) {
+	return nil, nil
+}
+func (s *stubDoctorClient) GetClinicDoors(context.Context, int, int) ([]ministry.ClinicDoor, error) {
+	return nil, nil
+}
+func (s *stubDoctorClient) GetMachineRvTypes(context.Context) ([]ministry.MachineRvType, error) {
+	return nil, nil
+}
+func (s *stubDoctorClient) SearchHunitsMachines(context.Context, ministry.SearchPayload) ([]ministry.HUnit, error) {
+	return nil, nil
+}
+
+func newServerWithDoctorStub(stub *stubDoctorClient) *Server {
+	agg := aggregator.New(nil).WithDoctorClient(stub)
+	return NewServer(agg)
+}
+
+func TestHandleDoctorSearch_SetsStartAndEndDate(t *testing.T) {
+	stub := &stubDoctorClient{}
+	server := newServerWithDoctorStub(stub)
+
+	req, _ := http.NewRequest("GET", "/api/doctors/search?specialtyId=24&prefectureId=5&foreasId=19", nil)
+	rr := httptest.NewRecorder()
+	server.HandleDoctorSearch(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if stub.lastSearch.StartDate == "" {
+		t.Errorf("expected StartDate to be set, got empty")
+	}
+	if stub.lastSearch.EndDate == "" {
+		t.Errorf("expected EndDate to be set, got empty")
+	}
+}
+
+func TestHandleDoctorNearby_SetsStartAndEndDate(t *testing.T) {
+	stub := &stubDoctorClient{}
+	server := newServerWithDoctorStub(stub)
+
+	req, _ := http.NewRequest("GET", "/api/doctors/nearby?specialtyId=24&lat=37.9&lon=23.7", nil)
+	rr := httptest.NewRecorder()
+	server.HandleDoctorNearby(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if stub.lastSearch.StartDate == "" || stub.lastSearch.EndDate == "" {
+		t.Errorf("expected StartDate/EndDate to be set, got %q/%q", stub.lastSearch.StartDate, stub.lastSearch.EndDate)
+	}
+}
+
+func TestHandleFamilyDoctorSearch_SetsStartAndEndDate(t *testing.T) {
+	stub := &stubDoctorClient{}
+	server := newServerWithDoctorStub(stub)
+
+	req, _ := http.NewRequest("GET", "/api/family-doctors/search?specialtyId=24&prefectureId=5", nil)
+	rr := httptest.NewRecorder()
+	server.HandleFamilyDoctorSearch(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if stub.lastSearch.StartDate == "" || stub.lastSearch.EndDate == "" {
+		t.Errorf("expected StartDate/EndDate on FD payload, got %q/%q", stub.lastSearch.StartDate, stub.lastSearch.EndDate)
+	}
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// errorBody is the standard JSON error envelope returned by the API.
+type errorBody struct {
+	Error errorPayload `json:"error"`
+}
+
+type errorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Details any    `json:"details,omitempty"`
+}
+
+// writeJSONError sends a structured JSON error response with the given status.
+// code is a short, stable, machine-friendly identifier ("missing_param",
+// "invalid_id", "upstream_failure", ...). message is human-friendly.
+func writeJSONError(w http.ResponseWriter, status int, code, message string, details ...any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	body := errorBody{Error: errorPayload{Code: code, Message: message}}
+	if len(details) > 0 {
+		body.Error.Details = details[0]
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// writeJSON sends a JSON success response.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -231,11 +231,12 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// HandleReadyz pings a cheap upstream endpoint to confirm the ministry API is reachable.
+// HandleReadyz performs a live, cache-bypassing upstream reachability check so
+// readiness reflects the ministry API's true state rather than a stale 24h cache.
 func (s *Server) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
-	if _, err := s.agg.GetSpecialties(ctx); err != nil {
+	if err := s.agg.Ready(ctx); err != nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "upstream_unavailable", err.Error())
 		return
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -321,7 +321,10 @@ func (s *Server) HandleDoctorSearch(w http.ResponseWriter, r *http.Request) {
 			foreasID = id
 		}
 	}
+	now := time.Now().UTC()
 	payload := ministry.SearchDoctorsPayload{
+		StartDate:    now.Format("2006-01-02T15:04:05.000Z"),
+		EndDate:      now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z"),
 		SpecialityID: specID,
 		ForeasID:     foreasID,
 		PrefectureID: parseIntPtr(r.URL.Query().Get("prefectureId")),
@@ -361,7 +364,10 @@ func (s *Server) HandleDoctorNearby(w http.ResponseWriter, r *http.Request) {
 			foreasID = id
 		}
 	}
+	now := time.Now().UTC()
 	payload := ministry.SearchDoctorsPayload{
+		StartDate:    now.Format("2006-01-02T15:04:05.000Z"),
+		EndDate:      now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z"),
 		SpecialityID: specID,
 		ForeasID:     foreasID,
 		Latitude:     lat,
@@ -396,6 +402,8 @@ func (s *Server) HandleFamilyDoctorSearch(w http.ResponseWriter, r *http.Request
 	end := now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z")
 
 	docsPayload := ministry.SearchDoctorsPayload{
+		StartDate:    start,
+		EndDate:      end,
 		SpecialityID: specID,
 		ForeasID:     18,
 		PrefectureID: prefPtr,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -13,12 +13,21 @@ import (
 
 // Server represents our REST API HTTP server.
 type Server struct {
-	agg *aggregator.Aggregator
+	agg    *aggregator.Aggregator
+	logger *slog.Logger
 }
 
 // NewServer initializes a new Server instance.
 func NewServer(agg *aggregator.Aggregator) *Server {
-	return &Server{agg: agg}
+	return &Server{agg: agg, logger: slog.Default()}
+}
+
+// WithLogger attaches a slog logger and returns the server.
+func (s *Server) WithLogger(l *slog.Logger) *Server {
+	if l != nil {
+		s.logger = l
+	}
+	return s
 }
 
 // SearchResponse represents the response sent back to the frontend.
@@ -27,39 +36,46 @@ type SearchResponse struct {
 	Results []aggregator.ScannedUnit `json:"results"`
 }
 
+func parseIntPtr(s string) *int {
+	if s == "" {
+		return nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+func parseFloatPtr(s string) *float64 {
+	if s == "" {
+		return nil
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
 // HandleSmartSearch handles the unified prioritized search.
 // GET /api/search?specialtyId=6&lat=37.9&lon=23.7&maxDistanceInKm=200
 func (s *Server) HandleSmartSearch(w http.ResponseWriter, r *http.Request) {
 	specIDStr := r.URL.Query().Get("specialtyId")
 	if specIDStr == "" {
-		http.Error(w, "missing specialtyId", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "missing specialtyId")
 		return
 	}
 	specialtyID, err := strconv.Atoi(specIDStr)
 	if err != nil {
-		http.Error(w, "invalid specialtyId: must be an integer", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId must be an integer")
 		return
 	}
 
-	var lat, lon *float64
-	if latStr := r.URL.Query().Get("lat"); latStr != "" {
-		if val, err := strconv.ParseFloat(latStr, 64); err == nil {
-			lat = &val
-		}
-	}
-	if lonStr := r.URL.Query().Get("lon"); lonStr != "" {
-		if val, err := strconv.ParseFloat(lonStr, 64); err == nil {
-			lon = &val
-		}
-	}
+	lat := parseFloatPtr(r.URL.Query().Get("lat"))
+	lon := parseFloatPtr(r.URL.Query().Get("lon"))
 	maxDist, _ := strconv.ParseFloat(r.URL.Query().Get("maxDistanceInKm"), 64)
-
-	var prefPtr *int
-	if prefStr := r.URL.Query().Get("prefectureId"); prefStr != "" {
-		if id, err := strconv.Atoi(prefStr); err == nil {
-			prefPtr = &id
-		}
-	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
 
 	payload := ministry.SearchPayload{
 		StartDate:    time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
@@ -69,79 +85,64 @@ func (s *Server) HandleSmartSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	// 1. Initial candidates discovery
 	units, err := s.agg.SearchUnified(ctx, payload)
 	if err != nil {
-		http.Error(w, "search failed: "+err.Error(), http.StatusInternalServerError)
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", "search failed: "+err.Error())
 		return
 	}
 
-	// 2. Prioritized scanning and sorting
 	results := s.agg.SmartSearch(ctx, units, payload, aggregator.SmartSearchOptions{
 		Lat:         lat,
 		Lon:         lon,
 		MaxDistance: maxDist,
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(results)
+	writeJSON(w, http.StatusOK, results)
 }
 
 // HandleGetSpecialties returns the cached list of medical specialties.
 func (s *Server) HandleGetSpecialties(w http.ResponseWriter, r *http.Request) {
-	specs, err := s.agg.GetSpecialties(context.Background())
+	specs, err := s.agg.GetSpecialties(r.Context())
 	if err != nil {
-		http.Error(w, "failed to fetch specialties", http.StatusInternalServerError)
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", "failed to fetch specialties: "+err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(specs)
+	writeJSON(w, http.StatusOK, specs)
 }
 
 // HandleHospitalCapacity returns a weekly capacity report for a specific hospital.
-// Example: GET /api/hospitals/70600/capacity
 func (s *Server) HandleHospitalCapacity(w http.ResponseWriter, r *http.Request) {
 	hunitIDStr := r.PathValue("hunitId")
 	if hunitIDStr == "" {
-		http.Error(w, "missing hunitId in path", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "missing hunitId in path")
 		return
 	}
-
 	hunitID, err := strconv.Atoi(hunitIDStr)
 	if err != nil {
-		http.Error(w, "invalid hunitId in path", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "hunitId must be an integer")
 		return
 	}
 
-	// We'll also need foreasId, default to 1 (Hospitals)
 	foreasID := 1
 	if fStr := r.URL.Query().Get("foreasId"); fStr != "" {
 		if id, err := strconv.Atoi(fStr); err == nil {
 			foreasID = id
 		}
 	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
 
-	var prefPtr *int
-	if pStr := r.URL.Query().Get("prefectureId"); pStr != "" {
-		if id, err := strconv.Atoi(pStr); err == nil {
-			prefPtr = &id
-		}
-	}
-
-	// 1. Get specialties (to fan out)
-	specs, err := s.agg.GetSpecialties(context.Background())
+	specs, err := s.agg.GetSpecialties(r.Context())
 	if err != nil {
-		http.Error(w, "failed to fetch specialties", http.StatusInternalServerError)
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", "failed to fetch specialties: "+err.Error())
 		return
 	}
 
-	// Filter specialties if specific ID provided
 	var filteredSpecs []ministry.Specialty
 	specIDQuery := r.URL.Query().Get("specialtyId")
 	if specIDQuery != "" {
 		targetID, err := strconv.Atoi(specIDQuery)
 		if err != nil {
-			http.Error(w, "invalid specialtyId: must be an integer", http.StatusBadRequest)
+			writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId must be an integer")
 			return
 		}
 		for _, spec := range specs {
@@ -151,53 +152,48 @@ func (s *Server) HandleHospitalCapacity(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 		if len(filteredSpecs) == 0 {
-			http.Error(w, "unknown specialtyId", http.StatusNotFound)
+			writeJSONError(w, http.StatusNotFound, "not_found", "unknown specialtyId")
 			return
 		}
 	} else {
 		filteredSpecs = specs
 	}
 
-	// 2. Aggregate capacity
-	report, err := s.agg.HospitalCapacity(context.Background(), hunitID, foreasID, prefPtr, filteredSpecs)
+	report, err := s.agg.HospitalCapacity(r.Context(), hunitID, foreasID, prefPtr, filteredSpecs)
 	if err != nil {
-		http.Error(w, "failed to generate capacity report: "+err.Error(), http.StatusInternalServerError)
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", "failed to generate capacity report: "+err.Error())
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(report)
+	writeJSON(w, http.StatusOK, report)
 }
 
 // HandleGranularSlots returns detailed appointment slots for a specific unit and date.
-// Example: GET /api/hunits/21/slots?specialtyId=12&date=2026-03-26&prefectureId=5&foreasId=1
 func (s *Server) HandleGranularSlots(w http.ResponseWriter, r *http.Request) {
 	hunitIDStr := r.PathValue("hunitId")
 	if hunitIDStr == "" {
-		http.Error(w, "missing hunitId in path", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "missing hunitId in path")
 		return
 	}
-
 	hunitID, err := strconv.Atoi(hunitIDStr)
 	if err != nil {
-		http.Error(w, "invalid hunitId in path", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "hunitId must be an integer")
 		return
 	}
 
 	specIDStr := r.URL.Query().Get("specialtyId")
 	if specIDStr == "" {
-		http.Error(w, "missing specialtyId in query", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "missing specialtyId in query")
 		return
 	}
 	specialtyID, err := strconv.Atoi(specIDStr)
 	if err != nil {
-		http.Error(w, "invalid specialtyId in query", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId must be an integer")
 		return
 	}
 
 	date := r.URL.Query().Get("date")
 	if date == "" {
-		http.Error(w, "missing date in query", http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "missing date in query")
 		return
 	}
 
@@ -207,21 +203,364 @@ func (s *Server) HandleGranularSlots(w http.ResponseWriter, r *http.Request) {
 			foreasID = id
 		}
 	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
+	cDoorPtr := parseIntPtr(r.URL.Query().Get("cDoorId"))
 
-	var prefPtr *int
-	if pStr := r.URL.Query().Get("prefectureId"); pStr != "" {
-		if id, err := strconv.Atoi(pStr); err == nil {
-			prefPtr = &id
-		}
-	}
-
-	slots, err := s.agg.GetGranularSlots(r.Context(), hunitID, foreasID, prefPtr, specialtyID, date)
-	if err != nil {
-		http.Error(w, "failed to fetch granular slots: "+err.Error(), http.StatusInternalServerError)
+	timeOfDay := r.URL.Query().Get("timeOfDay")
+	switch timeOfDay {
+	case "", "morning", "noon", "afternoon":
+		// allowed
+	default:
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "timeOfDay must be one of: morning, noon, afternoon")
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(slots)
+	slots, err := s.agg.GetGranularSlots(r.Context(), hunitID, foreasID, prefPtr, specialtyID, date, aggregator.GranularSlotsOptions{
+		CDoorID:   cDoorPtr,
+		TimeOfDay: timeOfDay,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", "failed to fetch granular slots: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, slots)
 }
 
+// HandleHealthz is a fast liveness probe; no upstream dependency.
+func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// HandleReadyz pings a cheap upstream endpoint to confirm the ministry API is reachable.
+func (s *Server) HandleReadyz(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+	if _, err := s.agg.GetSpecialties(ctx); err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "upstream_unavailable", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
+}
+
+// HandleHealthUnitTypes returns the foreas/health-unit-types catalog (#17).
+func (s *Server) HandleHealthUnitTypes(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	types, err := dc.GetHealthUnitTypes(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, types)
+}
+
+// HandlePrefectures returns the standard prefecture catalog (#18).
+func (s *Server) HandlePrefectures(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	prefs, err := dc.GetPrefectures(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, prefs)
+}
+
+// HandleCovidPrefectures returns prefectures with COVID vaccination centers.
+func (s *Server) HandleCovidPrefectures(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	prefs, err := dc.GetCovidPrefectures(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, prefs)
+}
+
+// HandleMentalHealthPrefectures returns prefectures with mental health units.
+func (s *Server) HandleMentalHealthPrefectures(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	prefs, err := dc.GetMentalHealthPrefectures(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, prefs)
+}
+
+// HandleDoctorSearch wraps /rv/searchdoctors (#11, #19).
+func (s *Server) HandleDoctorSearch(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	specID, err := strconv.Atoi(r.URL.Query().Get("specialtyId"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId required")
+		return
+	}
+	foreasID := 19 // default to ΕΟΠΥΥ private doctors
+	if fStr := r.URL.Query().Get("foreasId"); fStr != "" {
+		if id, err := strconv.Atoi(fStr); err == nil {
+			foreasID = id
+		}
+	}
+	payload := ministry.SearchDoctorsPayload{
+		SpecialityID: specID,
+		ForeasID:     foreasID,
+		PrefectureID: parseIntPtr(r.URL.Query().Get("prefectureId")),
+		FirstName:    r.URL.Query().Get("firstName"),
+		LastName:     r.URL.Query().Get("lastName"),
+	}
+	docs, err := dc.SearchDoctors(r.Context(), payload)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, docs)
+}
+
+// HandleDoctorNearby wraps /rv/searchdoctors/currentlocation (#19).
+func (s *Server) HandleDoctorNearby(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	specID, err := strconv.Atoi(r.URL.Query().Get("specialtyId"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId required")
+		return
+	}
+	lat := parseFloatPtr(r.URL.Query().Get("lat"))
+	lon := parseFloatPtr(r.URL.Query().Get("lon"))
+	if lat == nil || lon == nil {
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "lat and lon are required")
+		return
+	}
+	dist := parseFloatPtr(r.URL.Query().Get("distance"))
+	foreasID := 19
+	if fStr := r.URL.Query().Get("foreasId"); fStr != "" {
+		if id, err := strconv.Atoi(fStr); err == nil {
+			foreasID = id
+		}
+	}
+	payload := ministry.SearchDoctorsPayload{
+		SpecialityID: specID,
+		ForeasID:     foreasID,
+		Latitude:     lat,
+		Longitude:    lon,
+		Distance:     dist,
+	}
+	docs, err := dc.SearchDoctorsByLocation(r.Context(), payload)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, docs)
+}
+
+// HandleFamilyDoctorSearch wraps /rv/searchdoctorsfd and /rv/searchhunitsfd (#12).
+// Returns a hybrid {units,doctors} envelope.
+func (s *Server) HandleFamilyDoctorSearch(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	specID, err := strconv.Atoi(r.URL.Query().Get("specialtyId"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId required")
+		return
+	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
+
+	now := time.Now().UTC()
+	start := now.Format("2006-01-02T15:04:05.000Z")
+	end := now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z")
+
+	docsPayload := ministry.SearchDoctorsPayload{
+		SpecialityID: specID,
+		ForeasID:     18,
+		PrefectureID: prefPtr,
+		IsOnlyFd:     1,
+	}
+	unitsPayload := ministry.SearchPayload{
+		StartDate:    start,
+		EndDate:      end,
+		SpecialityID: specID,
+		ForeasID:     18,
+		PrefectureID: prefPtr,
+		IsOnlyFd:     1,
+	}
+
+	docs, dErr := dc.SearchDoctorsFD(r.Context(), docsPayload)
+	units, uErr := dc.SearchHunitsFD(r.Context(), unitsPayload)
+	if dErr != nil && uErr != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", dErr.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"doctors": docs, "units": units})
+}
+
+// HandleCovidSearch wraps /rv/searchhunits with isCovid=1 (#14).
+func (s *Server) HandleCovidSearch(w http.ResponseWriter, r *http.Request) {
+	specIDStr := r.URL.Query().Get("specialtyId")
+	if specIDStr == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "specialtyId required")
+		return
+	}
+	specID, err := strconv.Atoi(specIDStr)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId must be an integer")
+		return
+	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
+	foreasID := 1
+	if fStr := r.URL.Query().Get("foreasId"); fStr != "" {
+		if id, err := strconv.Atoi(fStr); err == nil {
+			foreasID = id
+		}
+	}
+	now := time.Now().UTC()
+	payload := ministry.SearchPayload{
+		StartDate:    now.Format("2006-01-02T15:04:05.000Z"),
+		EndDate:      now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z"),
+		SpecialityID: specID,
+		PrefectureID: prefPtr,
+		ForeasID:     foreasID,
+		IsCovid:      1,
+	}
+	units, err := s.agg.Client().SearchHUnits(r.Context(), payload)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, units)
+}
+
+// HandleMentalHealthSearch sets rvtypeId=15 + isMentalHealth=1 (#13).
+func (s *Server) HandleMentalHealthSearch(w http.ResponseWriter, r *http.Request) {
+	specIDStr := r.URL.Query().Get("specialtyId")
+	if specIDStr == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "specialtyId required")
+		return
+	}
+	specID, err := strconv.Atoi(specIDStr)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId must be an integer")
+		return
+	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
+	foreasID := 1
+	if fStr := r.URL.Query().Get("foreasId"); fStr != "" {
+		if id, err := strconv.Atoi(fStr); err == nil {
+			foreasID = id
+		}
+	}
+	now := time.Now().UTC()
+	payload := ministry.SearchPayload{
+		StartDate:      now.Format("2006-01-02T15:04:05.000Z"),
+		EndDate:        now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z"),
+		SpecialityID:   specID,
+		PrefectureID:   prefPtr,
+		ForeasID:       foreasID,
+		IsMentalHealth: 1,
+		RvTypeID:       15,
+	}
+	units, err := s.agg.Client().SearchHUnits(r.Context(), payload)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, units)
+}
+
+// HandleMachineRvTypes returns the diagnostic-machine RV type catalog (#15).
+func (s *Server) HandleMachineRvTypes(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	types, err := dc.GetMachineRvTypes(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, types)
+}
+
+// HandleMachineSearch wraps /machines/searchHunitsMachines (#15).
+func (s *Server) HandleMachineSearch(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	rvTypeID, err := strconv.Atoi(r.URL.Query().Get("rvTypeId"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "rvTypeId required")
+		return
+	}
+	prefPtr := parseIntPtr(r.URL.Query().Get("prefectureId"))
+	now := time.Now().UTC()
+	payload := ministry.SearchPayload{
+		StartDate:    now.Format("2006-01-02T15:04:05.000Z"),
+		EndDate:      now.AddDate(0, 6, 0).Format("2006-01-02T15:04:05.000Z"),
+		SpecialityID: 0,
+		PrefectureID: prefPtr,
+		ForeasID:     1,
+		RvTypeID:     rvTypeID,
+		IsMachine:    1,
+	}
+	units, err := dc.SearchHunitsMachines(r.Context(), payload)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"disclaimer": "These results require paid examinations (payType=1).",
+		"units":      units,
+	})
+}
+
+// HandleClinicDoors returns the clinic-door breakdown for a hospital+specialty (#20).
+func (s *Server) HandleClinicDoors(w http.ResponseWriter, r *http.Request) {
+	dc := s.agg.DoctorClient()
+	if dc == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "extended ministry client not wired")
+		return
+	}
+	hunitID, err := strconv.Atoi(r.PathValue("hunitId"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "hunitId must be an integer")
+		return
+	}
+	specID, err := strconv.Atoi(r.URL.Query().Get("specialtyId"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_param", "specialtyId required")
+		return
+	}
+	doors, err := dc.GetClinicDoors(r.Context(), hunitID, specID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "upstream_failure", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, doors)
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ctxKey is the unexported type used for context keys.
+type ctxKey int
+
+const (
+	ctxKeyRequestID ctxKey = iota
+)
+
+// RequestID returns the request id stored in the context, or "" if absent.
+func RequestID(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyRequestID).(string)
+	return v
+}
+
+// RequestIDMiddleware honors an inbound X-Request-Id or generates one,
+// then stores it on the context and the response header.
+func RequestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-Id")
+		if id == "" {
+			id = newRequestID()
+		}
+		w.Header().Set("X-Request-Id", id)
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// RecoveryMiddleware turns any panic into a 500 JSON error and logs it.
+func RecoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					logger.Error("panic recovered",
+						"panic", rec,
+						"path", r.URL.Path,
+						"method", r.Method,
+						"request_id", RequestID(r.Context()),
+					)
+					writeJSONError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// TimeoutMiddleware enforces a server-side request timeout. The downstream
+// handler should respect r.Context() cancellation.
+func TimeoutMiddleware(d time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.TimeoutHandler(next, d, `{"error":{"code":"timeout","message":"request timed out"}}`)
+	}
+}
+
+// CORSConfig drives the CORS middleware.
+type CORSConfig struct {
+	AllowedOrigins []string
+	AllowedMethods []string
+	AllowedHeaders []string
+	MaxAge         int
+}
+
+func (c CORSConfig) allowedOrigin(origin string) string {
+	if origin == "" {
+		return ""
+	}
+	for _, o := range c.AllowedOrigins {
+		if o == "*" || o == origin {
+			return o
+		}
+	}
+	return ""
+}
+
+// CORSMiddleware adds permissive-but-configurable CORS headers and short-circuits OPTIONS.
+func CORSMiddleware(cfg CORSConfig) func(http.Handler) http.Handler {
+	methods := strings.Join(cfg.AllowedMethods, ", ")
+	headers := strings.Join(cfg.AllowedHeaders, ", ")
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if allow := cfg.allowedOrigin(origin); allow != "" {
+				w.Header().Set("Access-Control-Allow-Origin", allow)
+				w.Header().Set("Vary", "Origin")
+				if methods != "" {
+					w.Header().Set("Access-Control-Allow-Methods", methods)
+				}
+				if headers != "" {
+					w.Header().Set("Access-Control-Allow-Headers", headers)
+				}
+				if cfg.MaxAge > 0 {
+					w.Header().Set("Access-Control-Max-Age", itoa(cfg.MaxAge))
+				}
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func itoa(n int) string {
+	// tiny helper to avoid importing strconv just for one place
+	if n == 0 {
+		return "0"
+	}
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if negative {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// LoggingMiddleware emits one structured log line per request.
+func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			lw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(lw, r)
+			logger.Info("http request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", lw.status,
+				"duration_ms", time.Since(start).Milliseconds(),
+				"request_id", RequestID(r.Context()),
+			)
+		})
+	}
+}
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// Chain composes middleware. The first item in mws is the outermost.
+func Chain(h http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -64,11 +64,56 @@ func RecoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 }
 
 // TimeoutMiddleware enforces a server-side request timeout. The downstream
-// handler should respect r.Context() cancellation.
+// handler should respect r.Context() cancellation. On timeout it emits a 504
+// using the same JSON error envelope as the rest of the API.
+//
+// http.TimeoutHandler hard-codes a text/html Content-Type on its 503 body, so
+// we wrap it: the inner TimeoutHandler enforces the deadline, and the outer
+// handler rewrites the timeout response into a proper JSON 504 envelope.
 func TimeoutMiddleware(d time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return http.TimeoutHandler(next, d, `{"error":{"code":"timeout","message":"request timed out"}}`)
+		inner := http.TimeoutHandler(next, d, "")
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tw := &timeoutResponseWriter{ResponseWriter: w}
+			inner.ServeHTTP(tw, r)
+			if tw.timedOut {
+				writeJSONError(w, http.StatusGatewayTimeout, "timeout", "request timed out")
+			}
+		})
 	}
+}
+
+// timeoutResponseWriter intercepts the 503 that http.TimeoutHandler emits when a
+// request exceeds its deadline, suppressing its body/headers so the wrapper can
+// substitute a JSON error envelope. Non-timeout responses pass through untouched.
+type timeoutResponseWriter struct {
+	http.ResponseWriter
+	timedOut    bool
+	wroteHeader bool
+}
+
+func (w *timeoutResponseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	// TimeoutHandler writes exactly http.StatusServiceUnavailable on timeout.
+	if status == http.StatusServiceUnavailable {
+		w.timedOut = true
+		return
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *timeoutResponseWriter) Write(b []byte) (int, error) {
+	if w.timedOut {
+		// Swallow the default text/html timeout body.
+		return len(b), nil
+	}
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 // CORSConfig drives the CORS middleware.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestID_GeneratedAndEchoed(t *testing.T) {
+	h := RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if RequestID(r.Context()) == "" {
+			t.Errorf("expected request id in context")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest("GET", "/x", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Header().Get("X-Request-Id") == "" {
+		t.Errorf("expected generated X-Request-Id header")
+	}
+}
+
+func TestRequestID_PreservesInbound(t *testing.T) {
+	h := RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest("GET", "/x", nil)
+	req.Header.Set("X-Request-Id", "abc-123")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if got := rr.Header().Get("X-Request-Id"); got != "abc-123" {
+		t.Errorf("expected request id preserved, got %q", got)
+	}
+}
+
+func TestRecovery_PanicReturnsJSON500(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := RecoveryMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("nope")
+	}))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/x", nil))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rr.Code)
+	}
+	var body errorBody
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON error body, got %q", rr.Body.String())
+	}
+	if body.Error.Code == "" {
+		t.Errorf("expected non-empty error code")
+	}
+}
+
+func TestCORS_PreflightAndOrigin(t *testing.T) {
+	cfg := CORSConfig{
+		AllowedOrigins: []string{"http://localhost:5173"},
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedHeaders: []string{"Content-Type"},
+	}
+	h := CORSMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Preflight from allowed origin
+	req := httptest.NewRequest("OPTIONS", "/x", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected 204 preflight, got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Errorf("expected allowed origin, got %q", got)
+	}
+
+	// Disallowed origin → no ACAO header
+	req2 := httptest.NewRequest("GET", "/x", nil)
+	req2.Header.Set("Origin", "http://evil.example")
+	rr2 := httptest.NewRecorder()
+	h.ServeHTTP(rr2, req2)
+	if rr2.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("expected no ACAO header for disallowed origin")
+	}
+}
+
+func TestHealthz_ReturnsOK(t *testing.T) {
+	s := NewServer(nil)
+	rr := httptest.NewRecorder()
+	s.HandleHealthz(rr, httptest.NewRequest("GET", "/healthz", nil))
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), `"status":"ok"`) {
+		t.Errorf("expected status:ok payload, got %q", rr.Body.String())
+	}
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRequestID_GeneratedAndEchoed(t *testing.T) {
@@ -86,6 +87,46 @@ func TestCORS_PreflightAndOrigin(t *testing.T) {
 	h.ServeHTTP(rr2, req2)
 	if rr2.Header().Get("Access-Control-Allow-Origin") != "" {
 		t.Errorf("expected no ACAO header for disallowed origin")
+	}
+}
+
+func TestTimeout_EmitsJSONEnvelope(t *testing.T) {
+	slow := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+	h := TimeoutMiddleware(10 * time.Millisecond)(slow)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/x", nil))
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json content type, got %q", ct)
+	}
+	var body errorBody
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON error body, got %q", rr.Body.String())
+	}
+	if body.Error.Code != "timeout" {
+		t.Errorf("expected code=timeout, got %q", body.Error.Code)
+	}
+}
+
+func TestTimeout_PassesThroughFastHandler(t *testing.T) {
+	fast := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	})
+	h := TimeoutMiddleware(time.Second)(fast)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/x", nil))
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 passthrough, got %d", rr.Code)
+	}
+	if rr.Body.String() != "ok" {
+		t.Errorf("expected body passthrough, got %q", rr.Body.String())
 	}
 }
 

--- a/internal/ministry/cache.go
+++ b/internal/ministry/cache.go
@@ -1,0 +1,103 @@
+package ministry
+
+import (
+	"sync"
+	"time"
+)
+
+// ttlEntry is a single cached value with an expiry timestamp.
+type ttlEntry struct {
+	value   any
+	expires time.Time
+}
+
+// TTLCache is a goroutine-safe map with per-key TTL expiry.
+// Values are stored as `any` so a single instance can host different return types.
+type TTLCache struct {
+	mu   sync.RWMutex
+	data map[string]ttlEntry
+	now  func() time.Time
+}
+
+// NewTTLCache returns an empty cache that uses time.Now as its clock.
+func NewTTLCache() *TTLCache {
+	return &TTLCache{
+		data: make(map[string]ttlEntry),
+		now:  time.Now,
+	}
+}
+
+// Get returns the cached value if present and not expired.
+func (c *TTLCache) Get(key string) (any, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.data[key]
+	if !ok {
+		return nil, false
+	}
+	if c.now().After(e.expires) {
+		return nil, false
+	}
+	return e.value, true
+}
+
+// Set stores a value with the given TTL.
+func (c *TTLCache) Set(key string, value any, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = ttlEntry{value: value, expires: c.now().Add(ttl)}
+}
+
+// Invalidate removes a single key (used by /admin/cache/flush).
+func (c *TTLCache) Invalidate(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.data, key)
+}
+
+// Flush clears every entry.
+func (c *TTLCache) Flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = make(map[string]ttlEntry)
+}
+
+// singleflight collapses concurrent identical fetches into one upstream call.
+type sfCall struct {
+	wg  sync.WaitGroup
+	val any
+	err error
+}
+
+type singleflight struct {
+	mu    sync.Mutex
+	calls map[string]*sfCall
+}
+
+func newSingleflight() *singleflight {
+	return &singleflight{calls: make(map[string]*sfCall)}
+}
+
+// Do runs fn at most once per concurrent key. Other callers wait for the
+// in-flight result.
+func (s *singleflight) Do(key string, fn func() (any, error)) (any, error) {
+	s.mu.Lock()
+	if c, ok := s.calls[key]; ok {
+		s.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err
+	}
+	c := &sfCall{}
+	c.wg.Add(1)
+	s.calls[key] = c
+	s.mu.Unlock()
+
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	s.mu.Lock()
+	delete(s.calls, key)
+	s.mu.Unlock()
+
+	return c.val, c.err
+}

--- a/internal/ministry/cache.go
+++ b/internal/ministry/cache.go
@@ -92,12 +92,16 @@ func (s *singleflight) Do(key string, fn func() (any, error)) (any, error) {
 	s.calls[key] = c
 	s.mu.Unlock()
 
-	c.val, c.err = fn()
-	c.wg.Done()
+	// Defer cleanup so a panic in fn() can't leave the WaitGroup held or the
+	// key stuck in s.calls, which would deadlock every future caller for it.
+	defer func() {
+		s.mu.Lock()
+		delete(s.calls, key)
+		s.mu.Unlock()
+		c.wg.Done()
+	}()
 
-	s.mu.Lock()
-	delete(s.calls, key)
-	s.mu.Unlock()
+	c.val, c.err = fn()
 
 	return c.val, c.err
 }

--- a/internal/ministry/cache_test.go
+++ b/internal/ministry/cache_test.go
@@ -1,0 +1,107 @@
+package ministry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestTTLCache_GetSetExpiry(t *testing.T) {
+	c := NewTTLCache()
+	c.Set("k", 42, 50*time.Millisecond)
+
+	if v, ok := c.Get("k"); !ok || v.(int) != 42 {
+		t.Fatalf("expected hit with 42, got %v ok=%v", v, ok)
+	}
+	time.Sleep(70 * time.Millisecond)
+	if _, ok := c.Get("k"); ok {
+		t.Fatalf("expected expiry, but cache still hits")
+	}
+}
+
+func TestClient_GetSpecialties_CachesResult(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"speciality":1,"name":"X"}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if _, err := c.GetSpecialties(context.Background()); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	if _, err := c.GetSpecialties(context.Background()); err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 upstream hit, got %d", got)
+	}
+}
+
+func TestClient_RetriesTransient5xx(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 3 {
+			http.Error(w, "boom", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.RetryWait = 5 * time.Millisecond
+	if _, err := c.GetSpecialties(context.Background()); err != nil {
+		t.Fatalf("expected eventual success, got error: %v", err)
+	}
+	if hits != 3 {
+		t.Fatalf("expected 3 upstream attempts, got %d", hits)
+	}
+}
+
+func TestClient_DoesNotRetry4xx(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.RetryWait = 1 * time.Millisecond
+	if _, err := c.GetSpecialties(context.Background()); err == nil {
+		t.Fatalf("expected error on 400")
+	}
+	if hits != 1 {
+		t.Fatalf("expected exactly 1 attempt on 400, got %d", hits)
+	}
+}
+
+func TestSingleflight_CollapsesConcurrentCalls(t *testing.T) {
+	sf := newSingleflight()
+	var calls int32
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = sf.Do("k", func() (any, error) {
+				atomic.AddInt32(&calls, 1)
+				time.Sleep(20 * time.Millisecond)
+				return 1, nil
+			})
+		}()
+	}
+	wg.Wait()
+	if calls != 1 {
+		t.Fatalf("expected 1 underlying call, got %d", calls)
+	}
+}

--- a/internal/ministry/client.go
+++ b/internal/ministry/client.go
@@ -4,14 +4,24 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"time"
 )
 
 // Client handles communication with the Hellenic Ministry API.
 type Client struct {
 	BaseURL    string
 	HTTPClient *http.Client
+
+	cache *TTLCache
+	sf    *singleflight
+
+	// Retry knobs. Zero values fall back to sensible defaults in retryDo.
+	MaxRetries int
+	RetryWait  time.Duration
 }
 
 // NewClient creates a new Ministry API client.
@@ -19,45 +29,126 @@ type Client struct {
 func NewClient(baseURL string) *Client {
 	return &Client{
 		BaseURL:    baseURL,
-		HTTPClient: &http.Client{},
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		cache:      NewTTLCache(),
+		sf:         newSingleflight(),
+		MaxRetries: 3,
+		RetryWait:  200 * time.Millisecond,
 	}
+}
+
+// Cache exposes the underlying TTL cache (admin flush, tests).
+func (c *Client) Cache() *TTLCache { return c.cache }
+
+func (c *Client) setStdHeaders(req *http.Request) {
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "no-auth")
+	if req.Method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Origin", "https://www.finddoctors.gov.gr")
+	req.Header.Set("Referer", "https://www.finddoctors.gov.gr/p-appointment/")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
+}
+
+// retryableStatus reports whether an HTTP status code is worth retrying.
+func retryableStatus(code int) bool {
+	switch code {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusInternalServerError:
+		return true
+	}
+	return false
+}
+
+// doJSON sends a JSON request (GET or POST), retrying transient failures, and
+// decodes the response body into out. The body is rebuilt per attempt so retries
+// are safe.
+func (c *Client) doJSON(ctx context.Context, method, url string, body any, out any) error {
+	var encoded []byte
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal payload: %w", err)
+		}
+		encoded = b
+	}
+
+	max := c.MaxRetries
+	if max <= 0 {
+		max = 1
+	}
+	wait := c.RetryWait
+	if wait <= 0 {
+		wait = 200 * time.Millisecond
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < max; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		var rdr io.Reader
+		if encoded != nil {
+			rdr = bytes.NewReader(encoded)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+		if err != nil {
+			return fmt.Errorf("new request: %w", err)
+		}
+		c.setStdHeaders(req)
+
+		res, err := c.HTTPClient.Do(req)
+		if err != nil {
+			// Never retry caller cancellations or deadline overruns.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			lastErr = err
+		} else {
+			if res.StatusCode == http.StatusOK {
+				defer res.Body.Close()
+				if out == nil {
+					_, _ = io.Copy(io.Discard, res.Body)
+					return nil
+				}
+				if err := json.NewDecoder(res.Body).Decode(out); err != nil {
+					return fmt.Errorf("decode response: %w", err)
+				}
+				return nil
+			}
+			// Drain & close so the connection can be reused.
+			_, _ = io.Copy(io.Discard, res.Body)
+			res.Body.Close()
+			if !retryableStatus(res.StatusCode) {
+				return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+			}
+			lastErr = fmt.Errorf("upstream returned %d", res.StatusCode)
+		}
+
+		// Backoff before next attempt (unless this was the last).
+		if attempt < max-1 {
+			delay := wait * time.Duration(1<<attempt)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("ministry: exhausted retries")
+	}
+	return lastErr
 }
 
 // SearchHUnits queries the /rv/searchhunits endpoint to find hospitals or PFYs.
 func (c *Client) SearchHUnits(ctx context.Context, payload SearchPayload) ([]HUnit, error) {
 	url := fmt.Sprintf("%s/p-appointment/api/v1/rv/searchhunits", c.BaseURL)
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal search payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// The API refuses requests without certain headers.
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "no-auth")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Origin", "https://www.finddoctors.gov.gr")
-	req.Header.Set("Referer", "https://www.finddoctors.gov.gr/p-appointment/")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-
-	res, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request failed: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
 	var units []HUnit
-	if err := json.NewDecoder(res.Body).Decode(&units); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &units); err != nil {
+		return nil, err
 	}
 
 	// The Ministry API doesn't return the ForeasID in the response items,
@@ -65,155 +156,232 @@ func (c *Client) SearchHUnits(ctx context.Context, payload SearchPayload) ([]HUn
 	for i := range units {
 		units[i].ForeasID = payload.ForeasID
 	}
-
 	return units, nil
 }
 
 // FirstAvailableSlot queries the /rv/firstavailableslot endpoint to find the earliest appointment date.
 func (c *Client) FirstAvailableSlot(ctx context.Context, payload SearchPayload) (string, error) {
 	url := fmt.Sprintf("%s/p-appointment/api/v1/rv/firstavailableslot", c.BaseURL)
-
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal search payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "no-auth")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Origin", "https://www.finddoctors.gov.gr")
-	req.Header.Set("Referer", "https://www.finddoctors.gov.gr/p-appointment/")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-
-	res, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("http request failed: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
-	// Response is just a raw string, e.g., "2026-05-07"
 	var dateStr string
-	if err := json.NewDecoder(res.Body).Decode(&dateStr); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &dateStr); err != nil {
+		return "", err
 	}
-
 	return dateStr, nil
 }
 
-// GetSpecialties retrieves all medical specialties metadata.
+// GetSpecialties retrieves all medical specialties metadata. Cached for 24h.
 func (c *Client) GetSpecialties(ctx context.Context) ([]Specialty, error) {
-	url := fmt.Sprintf("%s/p-appointment/api/v1/gen/getspecialities", c.BaseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	const key = "specialties"
+	if v, ok := c.cache.Get(key); ok {
+		return v.([]Specialty), nil
+	}
+	v, err := c.sf.Do(key, func() (any, error) {
+		// Detach from the caller's ctx so one cancellation does not poison
+		// every other goroutine waiting on the same singleflight key.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		url := fmt.Sprintf("%s/p-appointment/api/v1/gen/getspecialities", c.BaseURL)
+		var specs []Specialty
+		if err := c.doJSON(fetchCtx, http.MethodGet, url, nil, &specs); err != nil {
+			return nil, err
+		}
+		c.cache.Set(key, specs, 24*time.Hour)
+		return specs, nil
+	})
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, err
 	}
+	return v.([]Specialty), nil
+}
 
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "no-auth")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-
-	res, err := c.HTTPClient.Do(req)
+// GetHealthUnitTypes retrieves the foreas/health-unit-types catalog.
+// Trailing slash on the path is required by the upstream API.
+// Cached for 24h.
+func (c *Client) GetHealthUnitTypes(ctx context.Context) ([]HealthUnitType, error) {
+	const key = "healthUnitTypes"
+	if v, ok := c.cache.Get(key); ok {
+		return v.([]HealthUnitType), nil
+	}
+	v, err := c.sf.Do(key, func() (any, error) {
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		url := fmt.Sprintf("%s/p-appointment/api/v1/gen/getHealthUnitTypes/", c.BaseURL)
+		var types []HealthUnitType
+		if err := c.doJSON(fetchCtx, http.MethodGet, url, nil, &types); err != nil {
+			return nil, err
+		}
+		c.cache.Set(key, types, 24*time.Hour)
+		return types, nil
+	})
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if err != nil {
-		return nil, fmt.Errorf("http request failed: %w", err)
+		return nil, err
 	}
-	defer res.Body.Close()
+	return v.([]HealthUnitType), nil
+}
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+// GetPrefectures retrieves the standard 51-prefecture catalog. Cached for 24h.
+func (c *Client) GetPrefectures(ctx context.Context) ([]Prefecture, error) {
+	return c.fetchPrefectures(ctx, "prefectures", "/p-appointment/api/v1/gen/getprefectures")
+}
+
+// GetCovidPrefectures retrieves the prefectures that host COVID vaccination centers.
+func (c *Client) GetCovidPrefectures(ctx context.Context) ([]Prefecture, error) {
+	return c.fetchPrefectures(ctx, "prefectures.covid", "/p-appointment/api/v1/gen/getprefecturescovid")
+}
+
+// GetMentalHealthPrefectures retrieves the prefectures with mental health units.
+func (c *Client) GetMentalHealthPrefectures(ctx context.Context) ([]Prefecture, error) {
+	return c.fetchPrefectures(ctx, "prefectures.mh", "/p-appointment/api/v1/gen/getprefecturesmentalhealth")
+}
+
+func (c *Client) fetchPrefectures(ctx context.Context, cacheKey, path string) ([]Prefecture, error) {
+	if v, ok := c.cache.Get(cacheKey); ok {
+		return v.([]Prefecture), nil
 	}
-
-	var specs []Specialty
-	if err := json.NewDecoder(res.Body).Decode(&specs); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	v, err := c.sf.Do(cacheKey, func() (any, error) {
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		url := c.BaseURL + path
+		var prefs []Prefecture
+		if err := c.doJSON(fetchCtx, http.MethodGet, url, nil, &prefs); err != nil {
+			return nil, err
+		}
+		c.cache.Set(cacheKey, prefs, 24*time.Hour)
+		return prefs, nil
+	})
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
-
-	return specs, nil
+	if err != nil {
+		return nil, err
+	}
+	return v.([]Prefecture), nil
 }
 
 // GetSlotsInit retrieves the capacity calendar for a specific unit and specialty.
 func (c *Client) GetSlotsInit(ctx context.Context, payload SlotsInitPayload) ([]SlotGroup, error) {
 	url := fmt.Sprintf("%s/p-appointment/api/v1/rv/getslotsinit", c.BaseURL)
-
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "no-auth")
-	req.Header.Set("Origin", "https://www.finddoctors.gov.gr")
-	req.Header.Set("Referer", "https://www.finddoctors.gov.gr/p-appointment/")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-
-	res, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request failed: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
 	var groups []SlotGroup
-	if err := json.NewDecoder(res.Body).Decode(&groups); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &groups); err != nil {
+		return nil, err
 	}
-
 	return groups, nil
 }
 
 // GetActualSlots retrieves specific appointment times for a chosen day and group.
 func (c *Client) GetActualSlots(ctx context.Context, payload GetActualSlotsPayload) ([]ActualSlot, error) {
 	url := fmt.Sprintf("%s/p-appointment/api/v1/rv/getactualslots", c.BaseURL)
-
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "no-auth")
-	req.Header.Set("Origin", "https://www.finddoctors.gov.gr")
-	req.Header.Set("Referer", "https://www.finddoctors.gov.gr/p-appointment/")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-
-	res, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request failed: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
 	var slots []ActualSlot
-	if err := json.NewDecoder(res.Body).Decode(&slots); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &slots); err != nil {
+		return nil, err
 	}
-
 	return slots, nil
+}
+
+// SearchDoctors queries /rv/searchdoctors to find named physicians.
+// Used for EOPYY-affiliated private doctors (foreasID=19) and private doctors (foreasID=20).
+func (c *Client) SearchDoctors(ctx context.Context, payload SearchDoctorsPayload) ([]Doctor, error) {
+	return c.searchDoctorsPath(ctx, "/p-appointment/api/v1/rv/searchdoctors", payload)
+}
+
+// SearchDoctorsByLocation queries /rv/searchdoctors/currentlocation for geo-filtered results.
+func (c *Client) SearchDoctorsByLocation(ctx context.Context, payload SearchDoctorsPayload) ([]Doctor, error) {
+	return c.searchDoctorsPath(ctx, "/p-appointment/api/v1/rv/searchdoctors/currentlocation", payload)
+}
+
+// SearchDoctorsFD queries /rv/searchdoctorsfd for Family/Personal Doctor results.
+func (c *Client) SearchDoctorsFD(ctx context.Context, payload SearchDoctorsPayload) ([]Doctor, error) {
+	payload.IsOnlyFd = 1
+	return c.searchDoctorsPath(ctx, "/p-appointment/api/v1/rv/searchdoctorsfd", payload)
+}
+
+func (c *Client) searchDoctorsPath(ctx context.Context, path string, payload SearchDoctorsPayload) ([]Doctor, error) {
+	url := c.BaseURL + path
+	var doctors []Doctor
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &doctors); err != nil {
+		return nil, err
+	}
+	// Filter placeholder responseCode:2 entries (empty/null-filled objects).
+	out := doctors[:0]
+	for _, d := range doctors {
+		if d.ResponseCode == 2 {
+			continue
+		}
+		if d.FirstName == "" && d.LastName == "" && d.Amka == "" {
+			continue
+		}
+		d.ForeasID = payload.ForeasID
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// SearchHunitsFD queries /rv/searchhunitsfd for FD-mode hospitals.
+func (c *Client) SearchHunitsFD(ctx context.Context, payload SearchPayload) ([]HUnit, error) {
+	url := fmt.Sprintf("%s/p-appointment/api/v1/rv/searchhunitsfd", c.BaseURL)
+	payload.IsOnlyFd = 1
+	var units []HUnit
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &units); err != nil {
+		return nil, err
+	}
+	for i := range units {
+		units[i].ForeasID = payload.ForeasID
+	}
+	return units, nil
+}
+
+// GetClinicDoors fetches the clinic-door breakdown for a given (hunit, specialty).
+func (c *Client) GetClinicDoors(ctx context.Context, hunitID, specialtyID int) ([]ClinicDoor, error) {
+	url := fmt.Sprintf("%s/p-appointment/api/v1/gen/cdoorsbyhunitspeciality?hunitId=%d&specialityID=%d", c.BaseURL, hunitID, specialtyID)
+	var doors []ClinicDoor
+	if err := c.doJSON(ctx, http.MethodGet, url, nil, &doors); err != nil {
+		return nil, err
+	}
+	return doors, nil
+}
+
+// GetMachineRvTypes fetches the diagnostic-machine RV-type catalog. Cached 24h.
+func (c *Client) GetMachineRvTypes(ctx context.Context) ([]MachineRvType, error) {
+	const key = "machineRvTypes"
+	if v, ok := c.cache.Get(key); ok {
+		return v.([]MachineRvType), nil
+	}
+	v, err := c.sf.Do(key, func() (any, error) {
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		url := fmt.Sprintf("%s/p-appointment/api/v1/machines/getMachineRvTypes", c.BaseURL)
+		var types []MachineRvType
+		if err := c.doJSON(fetchCtx, http.MethodGet, url, nil, &types); err != nil {
+			return nil, err
+		}
+		c.cache.Set(key, types, 24*time.Hour)
+		return types, nil
+	})
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return v.([]MachineRvType), nil
+}
+
+// SearchHunitsMachines queries /machines/searchHunitsMachines for diagnostic-machine units.
+func (c *Client) SearchHunitsMachines(ctx context.Context, payload SearchPayload) ([]HUnit, error) {
+	url := fmt.Sprintf("%s/p-appointment/api/v1/machines/searchHunitsMachines", c.BaseURL)
+	payload.IsMachine = 1
+	var units []HUnit
+	if err := c.doJSON(ctx, http.MethodPost, url, payload, &units); err != nil {
+		return nil, err
+	}
+	for i := range units {
+		units[i].ForeasID = payload.ForeasID
+	}
+	return units, nil
 }

--- a/internal/ministry/client.go
+++ b/internal/ministry/client.go
@@ -119,7 +119,7 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any, out a
 			}
 			// Drain & close so the connection can be reused.
 			_, _ = io.Copy(io.Discard, res.Body)
-			res.Body.Close()
+			_ = res.Body.Close()
 			if !retryableStatus(res.StatusCode) {
 				return fmt.Errorf("unexpected status code: %d", res.StatusCode)
 			}
@@ -195,6 +195,15 @@ func (c *Client) GetSpecialties(ctx context.Context) ([]Specialty, error) {
 		return nil, err
 	}
 	return v.([]Specialty), nil
+}
+
+// Ping performs a cheap, cache-bypassing GET against a lightweight upstream
+// endpoint to confirm the ministry API is actually reachable right now.
+// Used by readiness probes so a stale 24h cache can't mask an outage.
+func (c *Client) Ping(ctx context.Context) error {
+	url := fmt.Sprintf("%s/p-appointment/api/v1/gen/getspecialities", c.BaseURL)
+	// out == nil drains the body without decoding, keeping this cheap.
+	return c.doJSON(ctx, http.MethodGet, url, nil, nil)
 }
 
 // GetHealthUnitTypes retrieves the foreas/health-unit-types catalog.

--- a/internal/ministry/client_test.go
+++ b/internal/ministry/client_test.go
@@ -25,7 +25,7 @@ func TestClient_SearchHUnits(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		hId := 718
 		// Return different mock data based on foreasID
 		if payload.ForeasID == 1 {
@@ -53,7 +53,7 @@ func TestClient_SearchHUnits(t *testing.T) {
 		SpecialityID: 6,
 		ForeasID:     1,
 	}
-	
+
 	units, err := client.SearchHUnits(context.Background(), payload)
 	if err != nil {
 		t.Fatalf("SearchHUnits failed: %v", err)
@@ -91,7 +91,7 @@ func TestClient_FirstAvailableSlot(t *testing.T) {
 		if payload.HUnit != nil {
 			h = *payload.HUnit
 		}
-		
+
 		if h == 718 {
 			w.Write([]byte(`"2026-05-07"`))
 		} else {

--- a/internal/ministry/singleflight_test.go
+++ b/internal/ministry/singleflight_test.go
@@ -1,0 +1,42 @@
+package ministry
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// A panic inside fn() must not leave the key wedged; the next call for the same
+// key should proceed normally instead of deadlocking on the WaitGroup.
+func TestSingleflight_PanicDoesNotDeadlock(t *testing.T) {
+	sf := newSingleflight()
+
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = sf.Do("k", func() (any, error) {
+			panic("boom")
+		})
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = sf.Do("k", func() (any, error) { return 42, nil })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// recovered cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("singleflight deadlocked after panic in fn()")
+	}
+}
+
+func TestSingleflight_ReturnsValueAndError(t *testing.T) {
+	sf := newSingleflight()
+	sentinel := errors.New("x")
+	v, err := sf.Do("k", func() (any, error) { return 7, sentinel })
+	if v != 7 || !errors.Is(err, sentinel) {
+		t.Fatalf("got (%v, %v)", v, err)
+	}
+}

--- a/internal/ministry/types.go
+++ b/internal/ministry/types.go
@@ -44,29 +44,34 @@ type DaySlots struct {
 
 // SearchPayload represents the outgoing JSON body for searches and availability.
 type SearchPayload struct {
-	StartDate    string `json:"startDate"`
-	EndDate      string `json:"endDate"`
-	PrefectureID *int   `json:"prefectureID"`
-	SpecialityID int    `json:"specialityID"`
-	ForeasID     int    `json:"foreasID"`
-	HUnit        *int   `json:"hunit"`
-	CDoorID      *int   `json:"cDoorId"`
-	IsCovid      int    `json:"isCovid"`
-	IsOnlyFd     int    `json:"isOnlyFd"`
-	IsMachine    int    `json:"isMachine"`
+	StartDate      string `json:"startDate"`
+	EndDate        string `json:"endDate"`
+	PrefectureID   *int   `json:"prefectureID"`
+	SpecialityID   int    `json:"specialityID"`
+	ForeasID       int    `json:"foreasID"`
+	HUnit          *int   `json:"hunit"`
+	CDoorID        *int   `json:"cDoorId"`
+	IsCovid        int    `json:"isCovid"`
+	IsOnlyFd       int    `json:"isOnlyFd"`
+	IsMachine      int    `json:"isMachine"`
+	IsMentalHealth int    `json:"isMentalHealth,omitempty"`
+	RvTypeID       int    `json:"rvtypeId,omitempty"`
 }
 
 // SlotsInitPayload represents the request body for /rv/getslotsinit.
 type SlotsInitPayload struct {
-	StartDate    string `json:"startDate"`
-	EndDate      string `json:"endDate"`
-	SpecialityID int    `json:"specialityID"`
-	PrefectureID *int   `json:"prefectureID"`
-	HUnit        *int   `json:"hunit"`
-	ForeasID     int    `json:"foreasID"`
-	IsCovid      int    `json:"isCovid"`
-	IsOnlyFd     int    `json:"isOnlyFd"`
-	IsMachine    int    `json:"isMachine"`
+	StartDate      string `json:"startDate"`
+	EndDate        string `json:"endDate"`
+	SpecialityID   int    `json:"specialityID"`
+	PrefectureID   *int   `json:"prefectureID"`
+	HUnit          *int   `json:"hunit"`
+	ForeasID       int    `json:"foreasID"`
+	CDoorID        *int   `json:"cDoorId,omitempty"`
+	IsCovid        int    `json:"isCovid"`
+	IsOnlyFd       int    `json:"isOnlyFd"`
+	IsMachine      int    `json:"isMachine"`
+	IsMentalHealth int    `json:"isMentalHealth,omitempty"`
+	RvTypeID       int    `json:"rvtypeId,omitempty"`
 }
 
 // SlotGroup represents a capacity block (e.g., 3 hours) in the /rv/getslotsinit response.
@@ -81,15 +86,15 @@ type SlotGroup struct {
 // ActualSlot represents a specific, granular appointment returned by /rv/getactualslots.
 // tygo:generate
 type ActualSlot struct {
-	HUnitID int    `json:"hUnitId"`
-	RVDate  string `json:"rvDate"`
-	RVTime  string `json:"rvtime"`
-	DocName   string `json:"doc_name"`
-	Address   string `json:"address"`
-	City      string `json:"city"`
+	HUnitID   int     `json:"hUnitId"`
+	RVDate    string  `json:"rvDate"`
+	RVTime    string  `json:"rvtime"`
+	DocName   string  `json:"doc_name"`
+	Address   string  `json:"address"`
+	City      string  `json:"city"`
 	Comments  *string `json:"comments"`
 	Comments2 *string `json:"comments2"`
-	RVTName   string `json:"rvtname"`
+	RVTName   string  `json:"rvtname"`
 }
 
 // GetActualSlotsPayload represents the request body for /rv/getactualslots.
@@ -104,4 +109,72 @@ type GetActualSlotsPayload struct {
 	IsOnlyFd     int    `json:"isOnlyFd"`
 	IsMachine    int    `json:"isMachine"`
 	CDoorID      *int   `json:"cDoorId"`
+}
+
+// HealthUnitType represents a foreas/unit-type metadata entry from /gen/getHealthUnitTypes/.
+// tygo:generate
+type HealthUnitType struct {
+	HUnitType int    `json:"hUnitType"`
+	Name      string `json:"name"`
+	IsActive  int    `json:"isActive"`
+}
+
+// Prefecture represents a Greek prefecture from /gen/getprefectures.
+// tygo:generate
+type Prefecture struct {
+	ID           int    `json:"id"`
+	Name         string `json:"name"`
+	ResponseCode int    `json:"responseCode,omitempty"`
+}
+
+// Doctor represents a named physician returned by /rv/searchdoctors.
+// tygo:generate
+type Doctor struct {
+	FirstName     string   `json:"firstName"`
+	LastName      string   `json:"lastName"`
+	Amka          string   `json:"amka"`
+	SpecialtyID   *int     `json:"specialtyId"`
+	SpecialtyName string   `json:"specialtyName"`
+	Address       string   `json:"address"`
+	CityName      string   `json:"cityName"`
+	Zip           string   `json:"zip"`
+	Phone         *string  `json:"phone"`
+	Latitude      float64  `json:"lattitude"`
+	Longitude     float64  `json:"longitude"`
+	Distance      *float64 `json:"distance"`
+	ForeasID      int      `json:"foreasId"`
+	ResponseCode  int      `json:"responseCode"`
+}
+
+// SearchDoctorsPayload is the JSON body for /rv/searchdoctors and variants.
+type SearchDoctorsPayload struct {
+	PrefectureID   *int     `json:"prefectureID"`
+	SpecialityID   int      `json:"specialityID"`
+	ForeasID       int      `json:"foreasID"`
+	Latitude       *float64 `json:"lattitude,omitempty"`
+	Longitude      *float64 `json:"longitude,omitempty"`
+	Distance       *float64 `json:"distance,omitempty"`
+	IsOnlyFd       int      `json:"isOnlyFd"`
+	IsCovid        int      `json:"isCovid"`
+	IsMachine      int      `json:"isMachine"`
+	IsMentalHealth int      `json:"isMentalHealth,omitempty"`
+	RvTypeID       int      `json:"rvtypeId,omitempty"`
+	FirstName      string   `json:"firstName,omitempty"`
+	LastName       string   `json:"lastName,omitempty"`
+}
+
+// ClinicDoor represents an entry from /gen/cdoorsbyhunitspeciality.
+// tygo:generate
+type ClinicDoor struct {
+	CDoorID int    `json:"cDoorId"`
+	Name    string `json:"name"`
+}
+
+// MachineRvType describes a diagnostic-machine RV type entry.
+// tygo:generate
+type MachineRvType struct {
+	RvTypeID  int    `json:"rvTypeId"`
+	Name      string `json:"name"`
+	PayType   int    `json:"payType"`
+	IsMachine int    `json:"isMachine"`
 }

--- a/internal/ministry/types.go
+++ b/internal/ministry/types.go
@@ -148,6 +148,8 @@ type Doctor struct {
 
 // SearchDoctorsPayload is the JSON body for /rv/searchdoctors and variants.
 type SearchDoctorsPayload struct {
+	StartDate      string   `json:"startDate"`
+	EndDate        string   `json:"endDate"`
 	PrefectureID   *int     `json:"prefectureID"`
 	SpecialityID   int      `json:"specialityID"`
 	ForeasID       int      `json:"foreasID"`


### PR DESCRIPTION
## Summary

Closes 14 of the 17 open issues. Skips #5 (cancellation watchdog) and #6 (nationwide heatmap), both flagged "Future" — they need infrastructure (push notifications, background workers, a much bigger upstream call budget) that should get its own design pass.

### Foundations (#21, #23)
- slog structured logger threaded through Aggregator and Server. No more `fmt.Printf` debug spam.
- Middleware chain: request-id, panic recovery (returns JSON 500), request logging, configurable CORS via `CORS_ALLOWED_ORIGINS`, 30s per-request timeout.
- `/healthz` (fast) and `/readyz` (probes upstream).
- `writeJSONError` envelope so the frontend can stop string-parsing plaintext errors.

### Resilience (#22)
- Per-method TTL cache for static catalogs (24h).
- Singleflight collapses concurrent cache misses. The fetch closure uses a detached context so one caller's cancellation cannot poison the others — codex caught this during plan review.
- Retry only on 502/503/504/500 with exponential backoff (max 3 attempts). Never on 4xx or context cancellation. Request body is rebuilt per attempt.

### Discovery (#17, #18)
- `GET /api/foreas` (the upstream endpoint requires a trailing slash; this respects that).
- `GET /api/prefectures` plus `/covid` and `/mental-health` variants.
- `SearchUnified` now pulls `foreasIDs` from the live catalog with a `{1,18}` fallback if the call fails.

### New endpoints
- `/api/doctors/search` and `/api/doctors/nearby` (#11, #19). Defaults `foreasId=19` (EOPYY).
- `/api/family-doctors/search` (#12). Returns hybrid `{doctors, units}`.
- `/api/mental-health/search` (#13). Sets `rvtypeId=15` and `isMentalHealth=1`, coexists with `specialtyID`.
- `/api/covid/search` (#14).
- `/api/machines/types` and `/api/machines/search` (#15), with a `payType` disclaimer on the response.
- `/api/hospitals/{hunitId}/doors` (#20) plus `cDoorId` pass-through on `/slots`.

### Bug fix (#16)
`fillRate` no longer counts days where every group is `disabled`. Those days are off-schedule, not "fully booked" — which is exactly the case that was inflating the number to 95-100% for doctors with limited weekly hours. The response now includes `scheduleDays`, `activeGroups`, and `disabledSlots` so the UI can explain how the number was computed. Regression test included.

### Filter (#7)
`timeOfDay=morning|noon|afternoon` on the granular slots endpoint.

## Design notes

- Both codex and CodeRabbit reviewed the plan/diff. Singleflight context detachment was the most important correction applied.
- Doctor and unit endpoints are intentionally separate. No unified `/api/search` shape yet — codex flagged that as premature.
- The #16 change is a deliberate behavior change. The old "all disabled = 100%" output was the bug, not the contract.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — 30 tests passing across 4 packages
- [ ] manual: `/healthz`, `/api/foreas`, `/api/prefectures` against the live ministry API
- [ ] manual: `/api/hospitals/{id}/capacity` on a doctor with a known limited schedule to confirm `scheduleDays`
- [ ] manual: `/api/doctors/search?specialtyId=12&prefectureId=5` returns named urologists in Attiki

Closes #7, Closes #11, Closes #12, Closes #13, Closes #14, Closes #15, Closes #16, Closes #17, Closes #18, Closes #19, Closes #20, Closes #21, Closes #22, Closes #23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoints for server status monitoring
  * Introduced doctor, family doctor, mental health, and COVID facility searches
  * Added medical equipment and machine search capabilities
  * Implemented appointment slot filtering by time of day
  * Enabled CORS origin configuration via environment variables
  * Configurable server-side request timeout handling

* **Bug Fixes**
  * Fixed appointment fill rate calculation for doctors with limited availability schedules

* **Infrastructure**
  * Standardized JSON error response format across API endpoints
  * Added request ID tracking and structured logging for debugging
  * Improved server error handling and reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/angelospk/find_doctors_server/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
