### PR TITLE
feat: cancellation watchdog (ICYMI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,44 @@ Both return a bare array of units.
 | `GET /api/prefectures/covid` | Prefectures with COVID vaccination centres. |
 | `GET /api/prefectures/mental-health` | Prefectures with mental-health units. |
 
+### Cancellation Watchdog (ICYMI)
+
+Register a watch on a specific unit + specialty; a background poller re-checks the
+first-available date and alerts you when an **earlier** slot appears (e.g. after a
+cancellation). Notifications go to Telegram and/or a webhook; either way the current
+state is always readable via `GET`.
+
+`POST /api/watches`
+```json
+{ "hunitId": 718, "specialtyId": 24, "foreasId": 1, "prefectureId": 5,
+  "telegramChatId": "123456789", "webhookUrl": "https://example.com/hook",
+  "expiresInDays": 14 }
+```
+`hunitId`, `specialtyId`, `foreasId` are **required**; `telegramChatId`/`webhookUrl`
+are optional channels (set neither to use poll-only). `expiresInDays` is clamped to
+1–30 (default 14). On create the server does one synchronous first-available check to
+seed the baseline, then returns `201` with the watch:
+```json
+{ "id": "5931bdd8…", "hunitId": 718, "specialtyId": 24, "foreasId": 1,
+  "currentDate": "2026-09-01", "lastNotifiedDate": "2026-09-01",
+  "status": "active", "createdAt": "…", "expiresAt": "…" }
+```
+
+`GET /api/watches/{id}` → current state (`currentDate`, `lastNotifiedDate`,
+`lastCheckedAt`, `status`); `404` if unknown.
+`DELETE /api/watches/{id}` → `204`, idempotent (sets `status: "cancelled"`).
+
+**Webhook payload** (POST to your `webhookUrl`):
+```json
+{ "watchId": "…", "hunitId": 718, "specialtyId": 24,
+  "newDate": "2026-07-01", "previousDate": "2026-09-01" }
+```
+
+Config (env): `WATCH_STATE_PATH` (default `./watchdog-state.json`),
+`WATCH_POLL_INTERVAL` (default `5m`), `TELEGRAM_BOT_TOKEN` (enables Telegram). State
+persists across restarts via an atomic JSON snapshot. Metrics:
+`watch_poll_failures_total`, `watch_notify_failures_total`.
+
 ## 🏗️ Development
 
 ### Running Tests (TDD)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	corsCfg := api.CORSConfig{
 		AllowedOrigins: corsOrigins(),
-		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+		AllowedMethods: []string{"GET", "POST", "DELETE", "OPTIONS"},
 		AllowedHeaders: []string{"Content-Type", "Authorization", "X-Request-Id"},
 		MaxAge:         600,
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/angelospk/find_doctors_server/internal/aggregator"
 	"github.com/angelospk/find_doctors_server/internal/api"
 	"github.com/angelospk/find_doctors_server/internal/ministry"
+	"github.com/angelospk/find_doctors_server/internal/watch"
 )
 
 func main() {
@@ -30,7 +31,20 @@ func main() {
 	logger.Info("initializing concurrent aggregator engine")
 	agg := aggregator.New(client).WithLogger(logger).WithDoctorClient(client)
 
-	server := api.NewServer(agg).WithLogger(logger)
+	logger.Info("initializing cancellation watchdog")
+	watchStore, err := watch.NewStore(envString("WATCH_STATE_PATH", "./watchdog-state.json"))
+	if err != nil {
+		logger.Error("watch store init failed", "error", err)
+		os.Exit(1)
+	}
+	notifiers := []watch.Notifier{watch.NewWebhookNotifier(&http.Client{Timeout: 10 * time.Second})}
+	if tok := os.Getenv("TELEGRAM_BOT_TOKEN"); tok != "" {
+		notifiers = append(notifiers, watch.NewTelegramNotifier(tok, &http.Client{Timeout: 10 * time.Second}))
+	}
+	poller := watch.NewPoller(watchStore, client, notifiers, logger)
+	poller.Interval = envDuration("WATCH_POLL_INTERVAL", 5*time.Minute)
+
+	server := api.NewServer(agg).WithLogger(logger).WithWatches(watchStore, client)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", server.HandleHealthz)
@@ -59,6 +73,10 @@ func main() {
 	mux.HandleFunc("GET /api/hospitals/{hunitId}/doors", server.HandleClinicDoors)
 
 	mux.HandleFunc("GET /api/heatmap", server.HandleNationwideHeatmap)
+
+	mux.HandleFunc("POST /api/watches", server.HandleCreateWatch)
+	mux.HandleFunc("GET /api/watches/{id}", server.HandleGetWatch)
+	mux.HandleFunc("DELETE /api/watches/{id}", server.HandleDeleteWatch)
 
 	// JSON catch-all so unknown routes get the standard error envelope instead
 	// of Go's default plain-text "404 page not found".
@@ -122,6 +140,13 @@ func main() {
 		}
 	}()
 
+	pollerDone := make(chan struct{})
+	go func() {
+		logger.Info("watchdog poller started", "interval", poller.Interval)
+		poller.Run(ctx)
+		close(pollerDone)
+	}()
+
 	select {
 	case err := <-serverErr:
 		logger.Error("server failed", "error", err)
@@ -134,6 +159,11 @@ func main() {
 		if err := publicSrv.Shutdown(shutdownCtx); err != nil {
 			logger.Error("graceful shutdown failed", "error", err)
 			os.Exit(1)
+		}
+		select {
+		case <-pollerDone:
+		case <-shutdownCtx.Done():
+			logger.Warn("watchdog poller did not drain within grace window")
 		}
 		logger.Info("server stopped cleanly")
 	}
@@ -194,6 +224,15 @@ func envFloat(k string, def float64) float64 {
 func envBool(k string, def bool) bool {
 	if v := os.Getenv(k); v != "" {
 		return strings.EqualFold(v, "true") || v == "1"
+	}
+	return def
+}
+
+func envDuration(k string, def time.Duration) time.Duration {
+	if v := os.Getenv(k); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
 	}
 	return def
 }

--- a/docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md
+++ b/docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md
@@ -18,7 +18,10 @@ adds the registry, the background poller, and the notification last mile.
   ("any unit for this specialty near me") are a noted future extension, not in scope.
 - **Channels:** Telegram (human last mile) and webhook (for a frontend/integration).
   A watch may set either, both, or neither (neither = poll-only via `GET`).
-- **Persistence:** SQLite (pure-Go `modernc.org/sqlite`), survives restarts.
+- **Persistence:** in-memory map guarded by an `RWMutex`, with a **write-through
+  atomic JSON snapshot** (temp file + `os.Rename`). Zero new dependencies, fast,
+  crash-safe. Survives restarts. (Chosen over SQLite/bbolt for smallest footprint —
+  the data is a few hundred watch records at most.)
 
 Out of scope: user accounts/auth, email/web-push, multi-unit watches, booking.
 
@@ -28,7 +31,7 @@ New package `internal/watch`, plus three API handlers and `main.go` wiring.
 
 ```
 POST /api/watches ─┐
-GET  /api/watches/{id}   →  Store (SQLite)  ←──  Poller (ticker goroutine)
+GET  /api/watches/{id}   →  Store (map + JSON snapshot)  ←──  Poller (ticker goroutine)
 DELETE /api/watches/{id} ─┘                          │
                                                      ├─ aggregator.FirstAvailableSlot (rate-limited client)
                                                      └─ Notifier(s): Telegram, Webhook
@@ -51,24 +54,31 @@ DELETE /api/watches/{id} ─┘                          │
 | `Status` | string | `active` \| `expired` \| `cancelled` |
 | `CreatedAt` / `ExpiresAt` / `LastCheckedAt` | time | lifecycle |
 
-**`Store` interface** (SQLite-backed)
+**`Store` interface** (in-memory map + JSON snapshot)
 - `Create(ctx, Watch) (Watch, error)`
 - `Get(ctx, id) (Watch, error)` — `ErrNotFound` when missing
-- `Delete(ctx, id) error` — sets `status=cancelled`
-- `ListActive(ctx) ([]Watch, error)` — `status=active AND expiresAt > now`
-- `Update(ctx, Watch) error` — persists currentDate/lastNotified/lastChecked/status
-  via **conditional SQL** (`WHERE id=? AND status='active'`) so it can't resurrect a
-  cancelled/expired row from a stale in-memory snapshot.
+- `Delete(ctx, id) error` — sets `status=cancelled`, idempotent
+- `ListActive(ctx) ([]Watch, error)` — `status=active AND expiresAt > now`; returns
+  **copies** so callers can't mutate the map's records without going through `Apply`
+- `Apply(ctx, id, fn func(*Watch) bool) error` — the race-safe write primitive: under
+  the write lock, look up the watch, and **only if it is still `active`** call `fn` to
+  mutate it in place; `fn` returns whether anything changed. Replaces SQL conditional
+  updates — a watch `DELETE`d mid-tick is no longer active, so `fn` never runs and the
+  poller can't fire or resurrect it.
 
-Single `*sql.DB` (`modernc.org/sqlite`), schema created on startup (idempotent
-`CREATE TABLE IF NOT EXISTS`). DB path from `WATCH_DB_PATH` (default `./watchdog.db`).
+Backing: `map[string]*Watch` + `sync.RWMutex`. Every mutation (`Create`/`Delete`/
+`Apply`) write-through-persists the whole map via an **atomic snapshot**: marshal to
+JSON, write to `<path>.tmp`, `os.Rename` over `<path>`. On startup, load `<path>` if it
+exists (missing/empty = start fresh). Snapshot path from `WATCH_STATE_PATH`
+(default `./watchdog-state.json`).
 
-**Concurrency policy** (poller writes + HTTP reads/writes share the DB):
-- Open with WAL + busy timeout pragmas: `_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)`.
-- `db.SetMaxOpenConns(1)` for the MVP — write volume is tiny (one batch per poll
-  interval) and a single connection sidesteps SQLite writer-lock contention entirely.
-- Transactions are short and never wrap an upstream or notifier call — the poller
-  reads the active set, releases the DB, does network I/O, then writes results back.
+**Concurrency policy:**
+- Reads (`Get`/`ListActive`) take the read lock; mutations take the write lock.
+- The poller does network I/O (upstream + notifiers) **outside** any lock — it reads
+  the active set (copies), calls upstream/notifiers, then writes each result back via
+  `Apply`, which re-checks `active` atomically. No lock is ever held across I/O.
+- The whole-map JSON rewrite is cheap at this scale; the poller persists at most once
+  per changed watch per tick.
 
 **`Poller`**
 - Started as a goroutine from `main.go`, bound to the existing signal context.
@@ -103,10 +113,9 @@ Single `*sql.DB` (`modernc.org/sqlite`), schema created on startup (idempotent
 - Expiry: when `now > ExpiresAt`, set `status=expired` and stop polling it.
 - Per-watch upstream error: log + metric, leave `CurrentDate`/`LastNotifiedDate`
   untouched, retry next tick. First poll returning empty → leave nil, retry.
-- **Cancel/notify race:** the poller re-reads (or conditionally updates) watch status
-  immediately before notifying. State writes use conditional SQL
-  (`UPDATE ... WHERE id=? AND status='active'`) so a watch `DELETE`d mid-tick never
-  fires a notification and never resurrects.
+- **Cancel/notify race:** all writes go through `Store.Apply`, which mutates a watch
+  only while it is still `active` (under the write lock). A watch `DELETE`d mid-tick
+  is no longer active, so its post-poll write is a no-op and no notification fires.
 
 **`Notifier` interface**: `Notify(ctx, Watch, newDate string) error`
 - `TelegramNotifier` — POSTs to `https://api.telegram.org/bot<token>/sendMessage`
@@ -141,21 +150,24 @@ All errors use the existing `writeJSONError` envelope and codes.
 ## Error Handling
 
 - **Upstream poll failure:** counted in a `watch_poll_failures_total` metric, logged
-  at WARN; watch is skipped this tick (no baseline change, no notify).
+  at WARN; watch is skipped this tick (no state change, no notify).
 - **Notifier failure:** logged + `watch_notify_failures_total`. `LastNotifiedDate`
   advances **only** when at least one configured notifier succeeds. If all fail,
-  `LastNotifiedDate` stays behind `BaselineDate`, so the next tick re-attempts the
+  `LastNotifiedDate` stays behind `CurrentDate`, so the next tick re-attempts the
   notification (see the Notify state model above). A watch with neither channel set
-  is poll-only: `LastNotifiedDate` simply tracks `BaselineDate` and the user reads
+  is poll-only: `LastNotifiedDate` simply tracks `CurrentDate` and the user reads
   state via `GET /api/watches/{id}`.
-- **DB failure on startup:** fatal (server exits) — persistence is a hard dependency.
-- **Bad input:** 400 with envelope, before any DB write.
+- **Snapshot load failure on startup:** a corrupt/unreadable `WATCH_STATE_PATH` is
+  fatal (server exits) rather than silently dropping watches; a *missing* file is
+  fine (start fresh). A snapshot *write* failure mid-run is logged + metric'd; the
+  in-memory state stays authoritative and the next mutation retries the write.
+- **Bad input:** 400 with envelope, before any state mutation.
 
 ## Configuration (env)
 
 | var | default | meaning |
 |-----|---------|---------|
-| `WATCH_DB_PATH` | `./watchdog.db` | SQLite file |
+| `WATCH_STATE_PATH` | `./watchdog-state.json` | JSON snapshot file |
 | `WATCH_POLL_INTERVAL` | `5m` | poll cadence |
 | `WATCH_MAX_DAYS` | `30` | hard cap on `expiresInDays` |
 | `WATCH_SHUTDOWN_GRACE` | `10s` | max drain time for an in-flight poll tick on shutdown |
@@ -166,8 +178,6 @@ token. No behavior change for existing endpoints.
 
 ## Testing (TDD)
 
-- **Store:** CRUD round-trip + `ListActive` filtering on a temp SQLite file
-  (`t.TempDir()`); expired/cancelled excluded.
 - **Poller (primary eval criterion):** mock client returning seed→later→earlier→same
   sequences. Assert: seeding sets `LastNotifiedDate` with no notify; an earlier date
   fires the notifier **exactly once** with the new date and advances
@@ -182,7 +192,8 @@ token. No behavior change for existing endpoints.
   after create is detected; a date already present at create is the baseline and does
   not notify.
 - **Store:** CRUD round-trip + `ListActive` filtering (expired/cancelled excluded) on
-  a `t.TempDir()` SQLite file, WAL enabled.
+  a `t.TempDir()` snapshot file; reload-from-snapshot restores state; `Apply` is a
+  no-op on a cancelled watch.
 - **Notifiers:** `httptest.Server` asserting the Telegram `sendMessage` request shape
   and the webhook JSON payload; non-2xx → error.
 - **API:** create (happy + validation failures), get, delete, unknown-id 404.
@@ -191,7 +202,9 @@ token. No behavior change for existing endpoints.
 ## Decisions (locked during brainstorming)
 
 1. Notify mechanism: webhook + polling endpoint (core), **Telegram** as the human channel.
-2. Persistence: **SQLite** (pure-Go), survives restart.
+2. Persistence: **in-memory + atomic JSON snapshot** (zero deps, smallest/fastest),
+   survives restart. (Brainstorming picked SQLite; narrowed to JSON snapshot on the
+   "smallest and fastest" follow-up.)
 3. Scope: **per-unit** watches for MVP; search-wide deferred.
 
 ## Future extensions (not now)

--- a/docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md
+++ b/docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md
@@ -44,8 +44,8 @@ DELETE /api/watches/{id} ─┘                          │
 | `SpecialtyID` | int | target specialty |
 | `ForeasID` | int | unit type (1/18/19…), needed for the upstream call |
 | `PrefectureID` | *int | optional, passed through to the upstream payload |
-| `BaselineDate` | *string | best (earliest) first-date seen so far; nil until first successful poll |
-| `LastNotifiedDate` | *string | guards against duplicate notifications for the same date |
+| `CurrentDate` | *string | **latest observed** first-available date (can move up as slots fill, or down on a cancellation); nil until the first successful observation |
+| `LastNotifiedDate` | *string | earliest date the user has been successfully told about; the retry/dedup guard |
 | `TelegramChatID` | *string | optional channel |
 | `WebhookURL` | *string | optional channel (must be http/https, validated) |
 | `Status` | string | `active` \| `expired` \| `cancelled` |
@@ -56,32 +56,57 @@ DELETE /api/watches/{id} ─┘                          │
 - `Get(ctx, id) (Watch, error)` — `ErrNotFound` when missing
 - `Delete(ctx, id) error` — sets `status=cancelled`
 - `ListActive(ctx) ([]Watch, error)` — `status=active AND expiresAt > now`
-- `Update(ctx, Watch) error` — persists baseline/lastNotified/lastChecked/status
+- `Update(ctx, Watch) error` — persists currentDate/lastNotified/lastChecked/status
+  via **conditional SQL** (`WHERE id=? AND status='active'`) so it can't resurrect a
+  cancelled/expired row from a stale in-memory snapshot.
 
 Single `*sql.DB` (`modernc.org/sqlite`), schema created on startup (idempotent
 `CREATE TABLE IF NOT EXISTS`). DB path from `WATCH_DB_PATH` (default `./watchdog.db`).
 
+**Concurrency policy** (poller writes + HTTP reads/writes share the DB):
+- Open with WAL + busy timeout pragmas: `_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)`.
+- `db.SetMaxOpenConns(1)` for the MVP — write volume is tiny (one batch per poll
+  interval) and a single connection sidesteps SQLite writer-lock contention entirely.
+- Transactions are short and never wrap an upstream or notifier call — the poller
+  reads the active set, releases the DB, does network I/O, then writes results back.
+
 **`Poller`**
-- Started as a goroutine from `main.go`, bound to the existing signal context so it
-  drains on shutdown.
+- Started as a goroutine from `main.go`, bound to the existing signal context.
+- **Shutdown is bounded, not just "ctx-cancelled":** on ctx cancel the ticker stops
+  accepting new ticks; an in-flight tick's worker pool drains against a deadline
+  (`WATCH_SHUTDOWN_GRACE`, default 10s); every upstream and notifier call uses its own
+  per-call timeout (5s) derived from the tick context, so a wedged webhook/upstream
+  can't hang shutdown. `main.go` coordinates HTTP-server and poller shutdown via an
+  `errgroup`/`WaitGroup` so the process exits cleanly within the grace window.
 - Every `WATCH_POLL_INTERVAL` (default `5m`, jittered ±20%): `ListActive`, then for
   each watch call `FirstAvailableSlot` through the aggregator's existing
   rate-limited client (respects `MINISTRY_MAX_CONCURRENCY`; bounded worker pool).
 - Dates are `YYYY-MM-DD` strings, so lexicographic order == chronological order.
+- **Seed at creation (no swallow window).** `POST /api/watches` performs one
+  synchronous `FirstAvailableSlot` call and seeds `CurrentDate = LastNotifiedDate =`
+  that date. This closes the gap Codex flagged: a cancellation appearing between
+  create-time and the first poll would otherwise be silently absorbed into the
+  baseline. If the seed call fails (or returns empty), both stay nil and the poller
+  seeds on its first successful observation instead.
 - **Notify state model** (unambiguous, retry-safe):
-  - *First successful poll* sets **both** `BaselineDate = d` and `LastNotifiedDate = d`
-    and sends **no** notification. Rationale: the user got the starting date from the
-    search before creating the watch, so the baseline is already "known".
+  - *Seeding* (create-time, or the poller's first successful observation if seeding
+    failed) sets `CurrentDate = LastNotifiedDate = d` and sends **no** notification.
   - *Each later poll* with observed non-empty `d`:
-    - `BaselineDate = d` (it always reflects the latest observed first-date).
-    - If `d < LastNotifiedDate`: an improvement the user hasn't been told about →
-      attempt notifiers. **Only on notifier success** set `LastNotifiedDate = d`.
-  - This makes `LastNotifiedDate` the single retry guard: if notify fails,
-    `LastNotifiedDate` lags `BaselineDate`, and the next tick (observing the same or
-    an even earlier `d`) re-attempts because `d < LastNotifiedDate` still holds.
+    - `CurrentDate = d` (always the latest observed first-date — may be later or earlier).
+    - If `d < LastNotifiedDate`: an earlier slot the user hasn't been told about →
+      attempt notifiers. **Only when at least one configured notifier succeeds** set
+      `LastNotifiedDate = d`.
+  - `LastNotifiedDate` is the single dedup + retry guard: if every notifier fails it
+    lags `CurrentDate`, so the next tick re-attempts (the condition `d < LastNotifiedDate`
+    still holds). Per-channel delivery state is **not** tracked in MVP — "at least one
+    channel delivered" advances the guard; per-channel retry is a future extension.
 - Expiry: when `now > ExpiresAt`, set `status=expired` and stop polling it.
-- Per-watch upstream error: log + metric, leave `BaselineDate`/`LastNotifiedDate`
-  untouched, retry next tick.
+- Per-watch upstream error: log + metric, leave `CurrentDate`/`LastNotifiedDate`
+  untouched, retry next tick. First poll returning empty → leave nil, retry.
+- **Cancel/notify race:** the poller re-reads (or conditionally updates) watch status
+  immediately before notifying. State writes use conditional SQL
+  (`UPDATE ... WHERE id=? AND status='active'`) so a watch `DELETE`d mid-tick never
+  fires a notification and never resurrects.
 
 **`Notifier` interface**: `Notify(ctx, Watch, newDate string) error`
 - `TelegramNotifier` — POSTs to `https://api.telegram.org/bot<token>/sendMessage`
@@ -100,11 +125,14 @@ Single `*sql.DB` (`modernc.org/sqlite`), schema created on startup (idempotent
   "telegramChatId": "123456789", "webhookUrl": "https://example.com/hook",
   "expiresInDays": 14 }
 ```
-Validates required ints, `expiresInDays` clamped to 1–30 (default 14), webhook URL
-scheme http/https. Returns `201` with the created watch (envelope: bare object).
+Validates required ints, `expiresInDays` clamped to 1–`WATCH_MAX_DAYS` (default 14),
+webhook URL scheme http/https. Performs the synchronous seed poll (above), then
+returns `201` with the created watch (envelope: bare object). A failed seed call
+does not fail the request — the watch is created with `currentDate=null` and the
+poller seeds later.
 
-`GET /api/watches/{id}` → current state (`baselineDate`, `lastCheckedAt`, `status`).
-`404` JSON envelope when unknown.
+`GET /api/watches/{id}` → current state (`currentDate`, `lastNotifiedDate`,
+`lastCheckedAt`, `status`). `404` JSON envelope when unknown.
 
 `DELETE /api/watches/{id}` → `204`, idempotent.
 
@@ -130,6 +158,7 @@ All errors use the existing `writeJSONError` envelope and codes.
 | `WATCH_DB_PATH` | `./watchdog.db` | SQLite file |
 | `WATCH_POLL_INTERVAL` | `5m` | poll cadence |
 | `WATCH_MAX_DAYS` | `30` | hard cap on `expiresInDays` |
+| `WATCH_SHUTDOWN_GRACE` | `10s` | max drain time for an in-flight poll tick on shutdown |
 | `TELEGRAM_BOT_TOKEN` | (unset) | enables Telegram channel |
 
 Watchdog is **opt-in**: with no watches it does nothing; Telegram is inert without a
@@ -139,10 +168,21 @@ token. No behavior change for existing endpoints.
 
 - **Store:** CRUD round-trip + `ListActive` filtering on a temp SQLite file
   (`t.TempDir()`); expired/cancelled excluded.
-- **Poller:** mock client returning later→earlier→same sequences. Assert: first poll
-  seeds baseline with no notify; an earlier date fires the notifier exactly once with
-  the new date and advances baseline; a later/equal date does nothing; upstream error
-  leaves state intact.
+- **Poller (primary eval criterion):** mock client returning seed→later→earlier→same
+  sequences. Assert: seeding sets `LastNotifiedDate` with no notify; an earlier date
+  fires the notifier **exactly once** with the new date and advances
+  `LastNotifiedDate`; a later/equal date does nothing; an upstream error leaves state
+  intact and retries.
+- **Notify retry (eval criterion):** notifier fails on first attempt → `LastNotifiedDate`
+  does **not** advance → next tick with the same earlier date re-fires; succeeds →
+  advances and stops re-firing.
+- **Cancel/notify race (eval criterion):** `DELETE` between `ListActive` and the
+  notify step → conditional update is a no-op and **no** notification is sent.
+- **Seed-at-creation:** `POST` performs the synchronous seed; a date appearing only
+  after create is detected; a date already present at create is the baseline and does
+  not notify.
+- **Store:** CRUD round-trip + `ListActive` filtering (expired/cancelled excluded) on
+  a `t.TempDir()` SQLite file, WAL enabled.
 - **Notifiers:** `httptest.Server` asserting the Telegram `sendMessage` request shape
   and the webhook JSON payload; non-2xx → error.
 - **API:** create (happy + validation failures), get, delete, unknown-id 404.

--- a/docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md
+++ b/docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md
@@ -1,0 +1,161 @@
+# Cancellation Watchdog (ICYMI) — Design
+
+**Issue:** #5 — "Background worker to poll `/firstavailableslot` and notify user if an earlier date appears."
+**Date:** 2026-06-08
+**Status:** Approved design → ready for implementation plan
+
+## Goal
+
+Let a user register interest in a specific health unit + specialty and get pinged
+when an **earlier** first-available appointment date appears (typically because
+someone cancelled). The server already exposes `FirstAvailableSlot`; this feature
+adds the registry, the background poller, and the notification last mile.
+
+## Scope (MVP)
+
+- **Per-unit watches only.** A watch tracks one `hunitId` + `specialtyId` (plus the
+  `foreasId`/`prefectureId` that `FirstAvailableSlot` needs). Search-wide watches
+  ("any unit for this specialty near me") are a noted future extension, not in scope.
+- **Channels:** Telegram (human last mile) and webhook (for a frontend/integration).
+  A watch may set either, both, or neither (neither = poll-only via `GET`).
+- **Persistence:** SQLite (pure-Go `modernc.org/sqlite`), survives restarts.
+
+Out of scope: user accounts/auth, email/web-push, multi-unit watches, booking.
+
+## Architecture
+
+New package `internal/watch`, plus three API handlers and `main.go` wiring.
+
+```
+POST /api/watches ─┐
+GET  /api/watches/{id}   →  Store (SQLite)  ←──  Poller (ticker goroutine)
+DELETE /api/watches/{id} ─┘                          │
+                                                     ├─ aggregator.FirstAvailableSlot (rate-limited client)
+                                                     └─ Notifier(s): Telegram, Webhook
+```
+
+### Components
+
+**`Watch` (model)**
+| field | type | notes |
+|-------|------|-------|
+| `ID` | string | server-generated (crypto-random hex) |
+| `HUnitID` | int | target unit |
+| `SpecialtyID` | int | target specialty |
+| `ForeasID` | int | unit type (1/18/19…), needed for the upstream call |
+| `PrefectureID` | *int | optional, passed through to the upstream payload |
+| `BaselineDate` | *string | best (earliest) first-date seen so far; nil until first successful poll |
+| `LastNotifiedDate` | *string | guards against duplicate notifications for the same date |
+| `TelegramChatID` | *string | optional channel |
+| `WebhookURL` | *string | optional channel (must be http/https, validated) |
+| `Status` | string | `active` \| `expired` \| `cancelled` |
+| `CreatedAt` / `ExpiresAt` / `LastCheckedAt` | time | lifecycle |
+
+**`Store` interface** (SQLite-backed)
+- `Create(ctx, Watch) (Watch, error)`
+- `Get(ctx, id) (Watch, error)` — `ErrNotFound` when missing
+- `Delete(ctx, id) error` — sets `status=cancelled`
+- `ListActive(ctx) ([]Watch, error)` — `status=active AND expiresAt > now`
+- `Update(ctx, Watch) error` — persists baseline/lastNotified/lastChecked/status
+
+Single `*sql.DB` (`modernc.org/sqlite`), schema created on startup (idempotent
+`CREATE TABLE IF NOT EXISTS`). DB path from `WATCH_DB_PATH` (default `./watchdog.db`).
+
+**`Poller`**
+- Started as a goroutine from `main.go`, bound to the existing signal context so it
+  drains on shutdown.
+- Every `WATCH_POLL_INTERVAL` (default `5m`, jittered ±20%): `ListActive`, then for
+  each watch call `FirstAvailableSlot` through the aggregator's existing
+  rate-limited client (respects `MINISTRY_MAX_CONCURRENCY`; bounded worker pool).
+- Dates are `YYYY-MM-DD` strings, so lexicographic order == chronological order.
+- **Notify state model** (unambiguous, retry-safe):
+  - *First successful poll* sets **both** `BaselineDate = d` and `LastNotifiedDate = d`
+    and sends **no** notification. Rationale: the user got the starting date from the
+    search before creating the watch, so the baseline is already "known".
+  - *Each later poll* with observed non-empty `d`:
+    - `BaselineDate = d` (it always reflects the latest observed first-date).
+    - If `d < LastNotifiedDate`: an improvement the user hasn't been told about →
+      attempt notifiers. **Only on notifier success** set `LastNotifiedDate = d`.
+  - This makes `LastNotifiedDate` the single retry guard: if notify fails,
+    `LastNotifiedDate` lags `BaselineDate`, and the next tick (observing the same or
+    an even earlier `d`) re-attempts because `d < LastNotifiedDate` still holds.
+- Expiry: when `now > ExpiresAt`, set `status=expired` and stop polling it.
+- Per-watch upstream error: log + metric, leave `BaselineDate`/`LastNotifiedDate`
+  untouched, retry next tick.
+
+**`Notifier` interface**: `Notify(ctx, Watch, newDate string) error`
+- `TelegramNotifier` — POSTs to `https://api.telegram.org/bot<token>/sendMessage`
+  with `chat_id` + a human message ("Βρέθηκε νωρίτερο ραντεβού: <date> …"). Token
+  from `TELEGRAM_BOT_TOKEN`; if unset, Telegram notifications are skipped (logged).
+- `WebhookNotifier` — POSTs JSON `{watchId, hunitId, specialtyId, newDate, previousDate}`
+  to the watch's `WebhookURL`, 5s timeout, treats non-2xx as failure.
+- Notifier failure → log + metric; retried next tick because baseline only advances
+  after at least one notifier path is attempted (see Error Handling).
+
+### API
+
+`POST /api/watches` — body:
+```json
+{ "hunitId": 718, "specialtyId": 24, "foreasId": 1, "prefectureId": 5,
+  "telegramChatId": "123456789", "webhookUrl": "https://example.com/hook",
+  "expiresInDays": 14 }
+```
+Validates required ints, `expiresInDays` clamped to 1–30 (default 14), webhook URL
+scheme http/https. Returns `201` with the created watch (envelope: bare object).
+
+`GET /api/watches/{id}` → current state (`baselineDate`, `lastCheckedAt`, `status`).
+`404` JSON envelope when unknown.
+
+`DELETE /api/watches/{id}` → `204`, idempotent.
+
+All errors use the existing `writeJSONError` envelope and codes.
+
+## Error Handling
+
+- **Upstream poll failure:** counted in a `watch_poll_failures_total` metric, logged
+  at WARN; watch is skipped this tick (no baseline change, no notify).
+- **Notifier failure:** logged + `watch_notify_failures_total`. `LastNotifiedDate`
+  advances **only** when at least one configured notifier succeeds. If all fail,
+  `LastNotifiedDate` stays behind `BaselineDate`, so the next tick re-attempts the
+  notification (see the Notify state model above). A watch with neither channel set
+  is poll-only: `LastNotifiedDate` simply tracks `BaselineDate` and the user reads
+  state via `GET /api/watches/{id}`.
+- **DB failure on startup:** fatal (server exits) — persistence is a hard dependency.
+- **Bad input:** 400 with envelope, before any DB write.
+
+## Configuration (env)
+
+| var | default | meaning |
+|-----|---------|---------|
+| `WATCH_DB_PATH` | `./watchdog.db` | SQLite file |
+| `WATCH_POLL_INTERVAL` | `5m` | poll cadence |
+| `WATCH_MAX_DAYS` | `30` | hard cap on `expiresInDays` |
+| `TELEGRAM_BOT_TOKEN` | (unset) | enables Telegram channel |
+
+Watchdog is **opt-in**: with no watches it does nothing; Telegram is inert without a
+token. No behavior change for existing endpoints.
+
+## Testing (TDD)
+
+- **Store:** CRUD round-trip + `ListActive` filtering on a temp SQLite file
+  (`t.TempDir()`); expired/cancelled excluded.
+- **Poller:** mock client returning later→earlier→same sequences. Assert: first poll
+  seeds baseline with no notify; an earlier date fires the notifier exactly once with
+  the new date and advances baseline; a later/equal date does nothing; upstream error
+  leaves state intact.
+- **Notifiers:** `httptest.Server` asserting the Telegram `sendMessage` request shape
+  and the webhook JSON payload; non-2xx → error.
+- **API:** create (happy + validation failures), get, delete, unknown-id 404.
+- **Race:** poller + concurrent API access under `-race`.
+
+## Decisions (locked during brainstorming)
+
+1. Notify mechanism: webhook + polling endpoint (core), **Telegram** as the human channel.
+2. Persistence: **SQLite** (pure-Go), survives restart.
+3. Scope: **per-unit** watches for MVP; search-wide deferred.
+
+## Future extensions (not now)
+
+- Search-wide watches (specialty+prefecture across many units).
+- Email / Web Push channels behind the same `Notifier` interface.
+- Per-watch quiet hours; max-notifications cap.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/angelospk/find_doctors_server/internal/aggregator"
 	"github.com/angelospk/find_doctors_server/internal/ministry"
+	"github.com/angelospk/find_doctors_server/internal/watch"
 )
 
 // upstreamHealthTTL controls how long /healthz/upstream caches a successful
@@ -24,6 +25,10 @@ type Server struct {
 	upHealthMu sync.Mutex
 	upHealthOK bool
 	upHealthAt time.Time
+
+	// Cancellation watchdog (#5). nil when the feature isn't wired.
+	watches     *watch.Store
+	watchSeeder watch.SlotChecker
 }
 
 // NewServer initializes a new Server instance.

--- a/internal/api/watch_handlers.go
+++ b/internal/api/watch_handlers.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -16,6 +18,38 @@ func (s *Server) WithWatches(store *watch.Store, seeder watch.SlotChecker) *Serv
 	s.watches = store
 	s.watchSeeder = seeder
 	return s
+}
+
+// validateWebhookURL guards against SSRF: the watchdog POSTs to this URL from the
+// server, so it must be an http(s) URL whose host does not resolve to a loopback,
+// private, link-local, or otherwise internal address (e.g. cloud metadata).
+func validateWebhookURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return errors.New("webhookUrl must be an http(s) URL")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("webhookUrl must have a host")
+	}
+
+	var ips []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		ips = []net.IP{ip}
+	} else {
+		resolved, err := net.LookupIP(host)
+		if err != nil || len(resolved) == 0 {
+			return errors.New("webhookUrl host could not be resolved")
+		}
+		ips = resolved
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+			return errors.New("webhookUrl must point to a public host")
+		}
+	}
+	return nil
 }
 
 type createWatchRequest struct {
@@ -49,9 +83,8 @@ func (s *Server) HandleCreateWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.WebhookURL != nil && *req.WebhookURL != "" {
-		u, err := url.Parse(*req.WebhookURL)
-		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			writeJSONError(w, http.StatusBadRequest, "invalid_param", "webhookUrl must be an http(s) URL")
+		if err := validateWebhookURL(*req.WebhookURL); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_param", err.Error())
 			return
 		}
 	}

--- a/internal/api/watch_handlers.go
+++ b/internal/api/watch_handlers.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/angelospk/find_doctors_server/internal/watch"
+)
+
+// WithWatches wires the cancellation watchdog store and the seed checker used to
+// capture the first-available date at create time. Returns the server.
+func (s *Server) WithWatches(store *watch.Store, seeder watch.SlotChecker) *Server {
+	s.watches = store
+	s.watchSeeder = seeder
+	return s
+}
+
+type createWatchRequest struct {
+	HUnitID        int     `json:"hunitId"`
+	SpecialtyID    int     `json:"specialtyId"`
+	ForeasID       int     `json:"foreasId"`
+	PrefectureID   *int    `json:"prefectureId"`
+	TelegramChatID *string `json:"telegramChatId"`
+	WebhookURL     *string `json:"webhookUrl"`
+	ExpiresInDays  int     `json:"expiresInDays"`
+}
+
+const (
+	watchDefaultDays = 14
+	watchMaxDays     = 30
+)
+
+// HandleCreateWatch registers a per-unit watch and seeds its baseline date.
+func (s *Server) HandleCreateWatch(w http.ResponseWriter, r *http.Request) {
+	if s.watches == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "watchdog not enabled")
+		return
+	}
+	var req createWatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "malformed JSON body")
+		return
+	}
+	if req.HUnitID == 0 || req.SpecialtyID == 0 || req.ForeasID == 0 {
+		writeJSONError(w, http.StatusBadRequest, "missing_param", "hunitId, specialtyId and foreasId are required")
+		return
+	}
+	if req.WebhookURL != nil && *req.WebhookURL != "" {
+		u, err := url.Parse(*req.WebhookURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			writeJSONError(w, http.StatusBadRequest, "invalid_param", "webhookUrl must be an http(s) URL")
+			return
+		}
+	}
+
+	days := req.ExpiresInDays
+	if days <= 0 {
+		days = watchDefaultDays
+	}
+	if days > watchMaxDays {
+		days = watchMaxDays
+	}
+
+	wt := watch.Watch{
+		HUnitID:        req.HUnitID,
+		SpecialtyID:    req.SpecialtyID,
+		ForeasID:       req.ForeasID,
+		PrefectureID:   req.PrefectureID,
+		TelegramChatID: req.TelegramChatID,
+		WebhookURL:     req.WebhookURL,
+		ExpiresAt:      time.Now().AddDate(0, 0, days),
+	}
+
+	// Synchronous seed: capture the current first-available date so a cancellation
+	// arriving between now and the first poll isn't silently absorbed.
+	if s.watchSeeder != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		if date, err := s.watchSeeder.FirstAvailableSlot(ctx, watch.PayloadFor(wt)); err == nil && date != "" {
+			wt.CurrentDate = &date
+			wt.LastNotifiedDate = &date
+		} else if err != nil {
+			s.logger.Warn("watch seed poll failed", "error", err)
+		}
+	}
+
+	created, err := s.watches.Create(r.Context(), wt)
+	if err != nil {
+		s.logger.Warn("watch create failed", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "store_error", "could not persist watch")
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+// HandleGetWatch returns a watch's current state.
+func (s *Server) HandleGetWatch(w http.ResponseWriter, r *http.Request) {
+	if s.watches == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "watchdog not enabled")
+		return
+	}
+	got, err := s.watches.Get(r.Context(), r.PathValue("id"))
+	if err == watch.ErrNotFound {
+		writeJSONError(w, http.StatusNotFound, "not_found", "unknown watch id")
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", "could not read watch")
+		return
+	}
+	writeJSON(w, http.StatusOK, got)
+}
+
+// HandleDeleteWatch cancels a watch. Idempotent.
+func (s *Server) HandleDeleteWatch(w http.ResponseWriter, r *http.Request) {
+	if s.watches == nil {
+		writeJSONError(w, http.StatusNotImplemented, "feature_unavailable", "watchdog not enabled")
+		return
+	}
+	if err := s.watches.Delete(r.Context(), r.PathValue("id")); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", "could not cancel watch")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/watch_handlers_test.go
+++ b/internal/api/watch_handlers_test.go
@@ -102,6 +102,35 @@ func TestHandleCreateWatch_BadWebhookURLIs400(t *testing.T) {
 	}
 }
 
+func TestHandleCreateWatch_RejectsSSRFWebhook(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	for _, badURL := range []string{
+		"http://127.0.0.1:9999/hook",      // loopback
+		"http://10.0.0.5/hook",            // RFC1918 private
+		"http://169.254.169.254/metadata", // link-local cloud metadata
+	} {
+		body := `{"hunitId":718,"specialtyId":24,"foreasId":1,"webhookUrl":"` + badURL + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/watches", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		mux(s).ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for %s, got %d", badURL, rec.Code)
+		}
+	}
+}
+
+func TestHandleCreateWatch_AllowsPublicWebhook(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	// Public IP literal (no DNS needed): must be accepted.
+	body := `{"hunitId":718,"specialtyId":24,"foreasId":1,"webhookUrl":"https://93.184.216.34/hook"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/watches", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for public webhook, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHandleGetWatch_RoundTripAnd404(t *testing.T) {
 	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
 	created, _ := s.watches.Create(context.Background(), watch.Watch{HUnitID: 1, SpecialtyID: 2})

--- a/internal/api/watch_handlers_test.go
+++ b/internal/api/watch_handlers_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/angelospk/find_doctors_server/internal/ministry"
+	"github.com/angelospk/find_doctors_server/internal/watch"
+)
+
+type stubSeeder struct {
+	date string
+	err  error
+}
+
+func (s stubSeeder) FirstAvailableSlot(ctx context.Context, _ ministry.SearchPayload) (string, error) {
+	return s.date, s.err
+}
+
+func newWatchServer(t *testing.T, seeder watch.SlotChecker) *Server {
+	t.Helper()
+	store, err := watch.NewStore(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	return NewServer(nil).WithWatches(store, seeder)
+}
+
+func mux(s *Server) *http.ServeMux {
+	m := http.NewServeMux()
+	m.HandleFunc("POST /api/watches", s.HandleCreateWatch)
+	m.HandleFunc("GET /api/watches/{id}", s.HandleGetWatch)
+	m.HandleFunc("DELETE /api/watches/{id}", s.HandleDeleteWatch)
+	return m
+}
+
+func TestHandleCreateWatch_SeedsAndReturns201(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	body := `{"hunitId":718,"specialtyId":24,"foreasId":1,"prefectureId":5}`
+	req := httptest.NewRequest(http.MethodPost, "/api/watches", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got watch.Watch
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID == "" {
+		t.Error("expected an id")
+	}
+	if got.CurrentDate == nil || *got.CurrentDate != "2026-09-01" {
+		t.Errorf("expected seeded date, got %v", got.CurrentDate)
+	}
+	if got.LastNotifiedDate == nil || *got.LastNotifiedDate != "2026-09-01" {
+		t.Errorf("expected seeded LastNotifiedDate, got %v", got.LastNotifiedDate)
+	}
+}
+
+func TestHandleCreateWatch_SeedFailureStillCreates(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{err: context.DeadlineExceeded})
+	body := `{"hunitId":718,"specialtyId":24,"foreasId":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/watches", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 even when seed fails, got %d", rec.Code)
+	}
+	var got watch.Watch
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.CurrentDate != nil {
+		t.Errorf("expected nil CurrentDate after seed failure, got %v", *got.CurrentDate)
+	}
+}
+
+func TestHandleCreateWatch_MissingSpecialtyIs400(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	req := httptest.NewRequest(http.MethodPost, "/api/watches", strings.NewReader(`{"hunitId":718,"foreasId":1}`))
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleCreateWatch_BadWebhookURLIs400(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	body := `{"hunitId":718,"specialtyId":24,"foreasId":1,"webhookUrl":"ftp://nope"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/watches", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetWatch_RoundTripAnd404(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	created, _ := s.watches.Create(context.Background(), watch.Watch{HUnitID: 1, SpecialtyID: 2})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/watches/"+created.ID, nil)
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/watches/unknown", nil)
+	rec = httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteWatch_Returns204(t *testing.T) {
+	s := newWatchServer(t, stubSeeder{date: "2026-09-01"})
+	created, _ := s.watches.Create(context.Background(), watch.Watch{HUnitID: 1, SpecialtyID: 2})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/watches/"+created.ID, nil)
+	rec := httptest.NewRecorder()
+	mux(s).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+}

--- a/internal/watch/notifier.go
+++ b/internal/watch/notifier.go
@@ -1,0 +1,101 @@
+package watch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Notifier delivers a watch alert through one channel.
+//
+// attempted is false when the channel isn't configured on the watch (the
+// notifier simply skips it). When attempted is true, err reports whether
+// delivery succeeded.
+type Notifier interface {
+	Notify(ctx context.Context, w Watch, newDate string) (attempted bool, err error)
+}
+
+// WebhookNotifier POSTs a JSON alert to the watch's WebhookURL.
+type WebhookNotifier struct {
+	client *http.Client
+}
+
+func NewWebhookNotifier(client *http.Client) *WebhookNotifier {
+	return &WebhookNotifier{client: client}
+}
+
+func (n *WebhookNotifier) Notify(ctx context.Context, w Watch, newDate string) (bool, error) {
+	if w.WebhookURL == nil || *w.WebhookURL == "" {
+		return false, nil
+	}
+	var prev string
+	if w.LastNotifiedDate != nil {
+		prev = *w.LastNotifiedDate
+	}
+	body, err := json.Marshal(map[string]any{
+		"watchId":      w.ID,
+		"hunitId":      w.HUnitID,
+		"specialtyId":  w.SpecialtyID,
+		"newDate":      newDate,
+		"previousDate": prev,
+	})
+	if err != nil {
+		return true, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, *w.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return true, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return true, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return true, fmt.Errorf("watch: webhook returned %d", resp.StatusCode)
+	}
+	return true, nil
+}
+
+// TelegramNotifier sends a message via the Telegram Bot API.
+type TelegramNotifier struct {
+	token   string
+	client  *http.Client
+	BaseURL string // overridable for tests; defaults to the public Bot API
+}
+
+func NewTelegramNotifier(token string, client *http.Client) *TelegramNotifier {
+	return &TelegramNotifier{token: token, client: client, BaseURL: "https://api.telegram.org"}
+}
+
+func (n *TelegramNotifier) Notify(ctx context.Context, w Watch, newDate string) (bool, error) {
+	if w.TelegramChatID == nil || *w.TelegramChatID == "" || n.token == "" {
+		return false, nil
+	}
+	text := fmt.Sprintf("🔔 Βρέθηκε νωρίτερο ραντεβού: %s (μονάδα %d, ειδικότητα %d).", newDate, w.HUnitID, w.SpecialtyID)
+	body, err := json.Marshal(map[string]any{
+		"chat_id": *w.TelegramChatID,
+		"text":    text,
+	})
+	if err != nil {
+		return true, err
+	}
+	url := fmt.Sprintf("%s/bot%s/sendMessage", n.BaseURL, n.token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return true, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return true, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return true, fmt.Errorf("watch: telegram returned %d", resp.StatusCode)
+	}
+	return true, nil
+}

--- a/internal/watch/notifier_test.go
+++ b/internal/watch/notifier_test.go
@@ -1,0 +1,104 @@
+package watch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func strp(s string) *string { return &s }
+
+func TestWebhookNotifier_PostsPayload(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewWebhookNotifier(srv.Client())
+	w := sampleWatch()
+	w.ID = "abc"
+	w.WebhookURL = strp(srv.URL)
+	w.LastNotifiedDate = strp("2026-08-01")
+
+	attempted, err := n.Notify(context.Background(), w, "2026-07-01")
+	if !attempted || err != nil {
+		t.Fatalf("expected attempted+success, got attempted=%v err=%v", attempted, err)
+	}
+	if gotBody["watchId"] != "abc" || gotBody["newDate"] != "2026-07-01" || gotBody["previousDate"] != "2026-08-01" {
+		t.Errorf("unexpected payload: %+v", gotBody)
+	}
+}
+
+func TestWebhookNotifier_SkipsWhenNoURL(t *testing.T) {
+	n := NewWebhookNotifier(http.DefaultClient)
+	attempted, err := n.Notify(context.Background(), sampleWatch(), "2026-07-01")
+	if attempted || err != nil {
+		t.Errorf("expected skip, got attempted=%v err=%v", attempted, err)
+	}
+}
+
+func TestWebhookNotifier_Non2xxIsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n := NewWebhookNotifier(srv.Client())
+	w := sampleWatch()
+	w.WebhookURL = strp(srv.URL)
+
+	attempted, err := n.Notify(context.Background(), w, "2026-07-01")
+	if !attempted || err == nil {
+		t.Errorf("expected attempted with error, got attempted=%v err=%v", attempted, err)
+	}
+}
+
+func TestTelegramNotifier_SendsMessage(t *testing.T) {
+	var path string
+	var form map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &form)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	n := NewTelegramNotifier("TOK123", srv.Client())
+	n.BaseURL = srv.URL
+	w := sampleWatch()
+	w.TelegramChatID = strp("999")
+
+	attempted, err := n.Notify(context.Background(), w, "2026-07-01")
+	if !attempted || err != nil {
+		t.Fatalf("expected attempted+success, got attempted=%v err=%v", attempted, err)
+	}
+	if !strings.Contains(path, "botTOK123") || !strings.Contains(path, "sendMessage") {
+		t.Errorf("unexpected telegram path: %s", path)
+	}
+	if form["chat_id"] != "999" {
+		t.Errorf("expected chat_id 999, got %v", form["chat_id"])
+	}
+	if txt, _ := form["text"].(string); !strings.Contains(txt, "2026-07-01") {
+		t.Errorf("expected date in message text, got %q", txt)
+	}
+}
+
+func TestTelegramNotifier_SkipsWhenNoChatID(t *testing.T) {
+	n := NewTelegramNotifier("TOK", http.DefaultClient)
+	attempted, err := n.Notify(context.Background(), sampleWatch(), "2026-07-01")
+	if attempted || err != nil {
+		t.Errorf("expected skip, got attempted=%v err=%v", attempted, err)
+	}
+}

--- a/internal/watch/poller.go
+++ b/internal/watch/poller.go
@@ -87,8 +87,10 @@ func (p *Poller) RunOnce(ctx context.Context) error {
 	return nil
 }
 
-func (p *Poller) checkOne(ctx context.Context, w Watch) {
-	payload := ministry.SearchPayload{
+// PayloadFor builds the upstream first-available-slot request for a watch. Shared
+// by the poller and the create-time seed in the API layer.
+func PayloadFor(w Watch) ministry.SearchPayload {
+	return ministry.SearchPayload{
 		StartDate:    time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
 		EndDate:      time.Now().AddDate(0, 6, 0).UTC().Format("2006-01-02T15:04:05.000Z"),
 		SpecialityID: w.SpecialtyID,
@@ -96,6 +98,10 @@ func (p *Poller) checkOne(ctx context.Context, w Watch) {
 		PrefectureID: w.PrefectureID,
 		HUnit:        &w.HUnitID,
 	}
+}
+
+func (p *Poller) checkOne(ctx context.Context, w Watch) {
+	payload := PayloadFor(w)
 
 	cctx, cancel := context.WithTimeout(ctx, p.PerCall)
 	date, err := p.checker.FirstAvailableSlot(cctx, payload)

--- a/internal/watch/poller.go
+++ b/internal/watch/poller.go
@@ -1,0 +1,169 @@
+package watch
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/angelospk/find_doctors_server/internal/ministry"
+)
+
+var (
+	pollFailures = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "watch_poll_failures_total",
+		Help: "Upstream first-available-slot checks that failed during a watch poll.",
+	})
+	notifyFailures = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "watch_notify_failures_total",
+		Help: "Notifier deliveries that failed.",
+	})
+)
+
+const (
+	defaultPollInterval = 5 * time.Minute
+	defaultPerCall      = 5 * time.Second
+)
+
+// SlotChecker is the narrow upstream dependency the poller needs. The ministry
+// client satisfies it directly, so polls go through the rate-limited client.
+type SlotChecker interface {
+	FirstAvailableSlot(ctx context.Context, payload ministry.SearchPayload) (string, error)
+}
+
+// Poller re-checks active watches and fires notifiers when an earlier date appears.
+type Poller struct {
+	store     *Store
+	checker   SlotChecker
+	notifiers []Notifier
+	logger    *slog.Logger
+
+	Interval time.Duration
+	PerCall  time.Duration
+}
+
+func NewPoller(store *Store, checker SlotChecker, notifiers []Notifier, logger *slog.Logger) *Poller {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Poller{
+		store:     store,
+		checker:   checker,
+		notifiers: notifiers,
+		logger:    logger,
+		Interval:  defaultPollInterval,
+		PerCall:   defaultPerCall,
+	}
+}
+
+// Run polls on a ticker until ctx is cancelled.
+func (p *Poller) Run(ctx context.Context) {
+	t := time.NewTicker(p.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := p.RunOnce(ctx); err != nil {
+				p.logger.Warn("watch poll tick failed", "error", err)
+			}
+		}
+	}
+}
+
+// RunOnce performs a single poll over all active watches. Per-watch failures are
+// logged and metered, not surfaced.
+func (p *Poller) RunOnce(ctx context.Context) error {
+	active, err := p.store.ListActive(ctx)
+	if err != nil {
+		return err
+	}
+	for _, w := range active {
+		p.checkOne(ctx, w)
+	}
+	return nil
+}
+
+func (p *Poller) checkOne(ctx context.Context, w Watch) {
+	payload := ministry.SearchPayload{
+		StartDate:    time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		EndDate:      time.Now().AddDate(0, 6, 0).UTC().Format("2006-01-02T15:04:05.000Z"),
+		SpecialityID: w.SpecialtyID,
+		ForeasID:     w.ForeasID,
+		PrefectureID: w.PrefectureID,
+		HUnit:        &w.HUnitID,
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, p.PerCall)
+	date, err := p.checker.FirstAvailableSlot(cctx, payload)
+	cancel()
+	if err != nil {
+		pollFailures.Inc()
+		p.logger.Warn("watch poll failed", "watch", w.ID, "error", err)
+		return
+	}
+	if date == "" {
+		return // no slot available; nothing to record
+	}
+
+	// Re-read state: the check may have raced with a Delete.
+	cur, err := p.store.Get(ctx, w.ID)
+	if err != nil || cur.Status != StatusActive {
+		return
+	}
+
+	// First observation seeds the baseline without notifying.
+	if cur.LastNotifiedDate == nil {
+		_, _ = p.store.Apply(ctx, w.ID, func(w *Watch) bool {
+			w.CurrentDate = &date
+			w.LastNotifiedDate = &date
+			w.LastCheckedAt = time.Now()
+			return true
+		})
+		return
+	}
+
+	improvement := date < *cur.LastNotifiedDate
+	notified := true
+	if improvement {
+		notified = p.notify(ctx, cur, date)
+	}
+
+	_, _ = p.store.Apply(ctx, w.ID, func(w *Watch) bool {
+		w.CurrentDate = &date
+		w.LastCheckedAt = time.Now()
+		if improvement && notified {
+			w.LastNotifiedDate = &date
+		}
+		return true
+	})
+}
+
+// notify delivers to every notifier. It returns whether the guard may advance:
+// true when no channel is configured (poll-only) or at least one channel
+// delivered; false when channels were attempted and all failed.
+func (p *Poller) notify(ctx context.Context, w Watch, date string) bool {
+	attempted, succeeded := 0, 0
+	for _, n := range p.notifiers {
+		cctx, cancel := context.WithTimeout(ctx, p.PerCall)
+		ok, err := n.Notify(cctx, w, date)
+		cancel()
+		if !ok {
+			continue
+		}
+		attempted++
+		if err != nil {
+			notifyFailures.Inc()
+			p.logger.Warn("watch notify failed", "watch", w.ID, "error", err)
+		} else {
+			succeeded++
+		}
+	}
+	if attempted == 0 {
+		return true // poll-only watch
+	}
+	return succeeded >= 1
+}

--- a/internal/watch/poller_test.go
+++ b/internal/watch/poller_test.go
@@ -1,0 +1,180 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/angelospk/find_doctors_server/internal/ministry"
+)
+
+// --- mocks ---
+
+type mockChecker struct {
+	fn func(call int) (string, error)
+	n  int
+}
+
+func (m *mockChecker) FirstAvailableSlot(ctx context.Context, _ ministry.SearchPayload) (string, error) {
+	m.n++
+	return m.fn(m.n)
+}
+
+type recordNotifier struct {
+	calls    []string // dates it was asked to deliver
+	failNext bool
+}
+
+func (r *recordNotifier) Notify(ctx context.Context, w Watch, newDate string) (bool, error) {
+	r.calls = append(r.calls, newDate)
+	if r.failNext {
+		r.failNext = false
+		return true, errors.New("delivery failed")
+	}
+	return true, nil
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newPollerWith(t *testing.T, checker SlotChecker, notifiers ...Notifier) (*Poller, *Store) {
+	t.Helper()
+	s := newTestStore(t)
+	return NewPoller(s, checker, notifiers, quietLogger()), s
+}
+
+// seedWatch creates a watch that already has a known baseline date.
+func seededWatch(t *testing.T, s *Store, baseline string) Watch {
+	t.Helper()
+	w, _ := s.Create(context.Background(), sampleWatch())
+	_, _ = s.Apply(context.Background(), w.ID, func(w *Watch) bool {
+		w.CurrentDate = &baseline
+		w.LastNotifiedDate = &baseline
+		return true
+	})
+	got, _ := s.Get(context.Background(), w.ID)
+	return got
+}
+
+// --- tests ---
+
+func TestPoller_SeedsWithoutNotifying(t *testing.T) {
+	ch := &mockChecker{fn: func(int) (string, error) { return "2026-09-01", nil }}
+	notif := &recordNotifier{}
+	p, s := newPollerWith(t, ch, notif)
+	w, _ := s.Create(context.Background(), sampleWatch()) // no dates yet
+
+	if err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	got, _ := s.Get(context.Background(), w.ID)
+	if got.CurrentDate == nil || *got.CurrentDate != "2026-09-01" {
+		t.Errorf("expected seeded CurrentDate, got %v", got.CurrentDate)
+	}
+	if got.LastNotifiedDate == nil || *got.LastNotifiedDate != "2026-09-01" {
+		t.Errorf("expected seeded LastNotifiedDate, got %v", got.LastNotifiedDate)
+	}
+	if len(notif.calls) != 0 {
+		t.Errorf("seeding must not notify, got calls %v", notif.calls)
+	}
+}
+
+func TestPoller_NotifiesOnceOnEarlierDate(t *testing.T) {
+	ch := &mockChecker{fn: func(int) (string, error) { return "2026-07-01", nil }}
+	notif := &recordNotifier{}
+	p, s := newPollerWith(t, ch, notif)
+	w := seededWatch(t, s, "2026-09-01")
+
+	_ = p.RunOnce(context.Background()) // earlier -> notify
+	_ = p.RunOnce(context.Background()) // same -> no re-notify
+
+	if len(notif.calls) != 1 || notif.calls[0] != "2026-07-01" {
+		t.Fatalf("expected exactly one notify for 2026-07-01, got %v", notif.calls)
+	}
+	got, _ := s.Get(context.Background(), w.ID)
+	if got.LastNotifiedDate == nil || *got.LastNotifiedDate != "2026-07-01" {
+		t.Errorf("expected LastNotifiedDate advanced, got %v", got.LastNotifiedDate)
+	}
+}
+
+func TestPoller_LaterDateDoesNotNotify(t *testing.T) {
+	ch := &mockChecker{fn: func(int) (string, error) { return "2026-12-01", nil }}
+	notif := &recordNotifier{}
+	p, s := newPollerWith(t, ch, notif)
+	w := seededWatch(t, s, "2026-09-01")
+
+	_ = p.RunOnce(context.Background())
+
+	if len(notif.calls) != 0 {
+		t.Errorf("later date must not notify, got %v", notif.calls)
+	}
+	got, _ := s.Get(context.Background(), w.ID)
+	if got.CurrentDate == nil || *got.CurrentDate != "2026-12-01" {
+		t.Errorf("expected CurrentDate updated to later date, got %v", got.CurrentDate)
+	}
+	if *got.LastNotifiedDate != "2026-09-01" {
+		t.Errorf("LastNotifiedDate must not change, got %v", *got.LastNotifiedDate)
+	}
+}
+
+func TestPoller_UpstreamErrorLeavesStateIntact(t *testing.T) {
+	ch := &mockChecker{fn: func(int) (string, error) { return "", errors.New("upstream down") }}
+	notif := &recordNotifier{}
+	p, s := newPollerWith(t, ch, notif)
+	w := seededWatch(t, s, "2026-09-01")
+
+	if err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce should not surface per-watch errors: %v", err)
+	}
+	got, _ := s.Get(context.Background(), w.ID)
+	if *got.CurrentDate != "2026-09-01" || *got.LastNotifiedDate != "2026-09-01" {
+		t.Errorf("state must be untouched on upstream error, got %+v", got)
+	}
+	if len(notif.calls) != 0 {
+		t.Errorf("no notify on error, got %v", notif.calls)
+	}
+}
+
+func TestPoller_RetriesNotifyAfterFailure(t *testing.T) {
+	ch := &mockChecker{fn: func(int) (string, error) { return "2026-07-01", nil }}
+	notif := &recordNotifier{failNext: true}
+	p, s := newPollerWith(t, ch, notif)
+	w := seededWatch(t, s, "2026-09-01")
+
+	_ = p.RunOnce(context.Background()) // notify fails -> guard not advanced
+	got, _ := s.Get(context.Background(), w.ID)
+	if got.LastNotifiedDate == nil || *got.LastNotifiedDate != "2026-09-01" {
+		t.Errorf("guard must not advance on notify failure, got %v", got.LastNotifiedDate)
+	}
+
+	_ = p.RunOnce(context.Background()) // retries, succeeds
+	if len(notif.calls) != 2 {
+		t.Errorf("expected a retry (2 calls), got %v", notif.calls)
+	}
+	got, _ = s.Get(context.Background(), w.ID)
+	if *got.LastNotifiedDate != "2026-07-01" {
+		t.Errorf("guard must advance after successful retry, got %v", *got.LastNotifiedDate)
+	}
+}
+
+func TestPoller_CancelDuringCheckSuppressesNotify(t *testing.T) {
+	notif := &recordNotifier{}
+	s := newTestStore(t)
+	w := seededWatch(t, s, "2026-09-01")
+
+	// The checker cancels the watch mid-tick, then reports an earlier date.
+	ch := &mockChecker{fn: func(int) (string, error) {
+		_ = s.Delete(context.Background(), w.ID)
+		return "2026-07-01", nil
+	}}
+	p := NewPoller(s, ch, []Notifier{notif}, quietLogger())
+
+	_ = p.RunOnce(context.Background())
+
+	if len(notif.calls) != 0 {
+		t.Errorf("cancelled watch must not notify, got %v", notif.calls)
+	}
+}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -1,0 +1,154 @@
+package watch
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// Store is an in-memory watch registry backed by a write-through atomic JSON
+// snapshot. All mutations persist the whole map via temp-file + rename.
+type Store struct {
+	path string
+
+	mu      sync.RWMutex
+	watches map[string]*Watch
+}
+
+// NewStore opens (or creates) a store backed by the snapshot at path. A missing
+// file starts empty; a corrupt file is a hard error.
+func NewStore(path string) (*Store, error) {
+	s := &Store{path: path, watches: make(map[string]*Watch)}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *Store) load() error {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("watch: read snapshot: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var list []*Watch
+	if err := json.Unmarshal(data, &list); err != nil {
+		return fmt.Errorf("watch: parse snapshot %s: %w", s.path, err)
+	}
+	for _, w := range list {
+		s.watches[w.ID] = w
+	}
+	return nil
+}
+
+// persist writes the whole map to the snapshot atomically. Caller holds s.mu.
+func (s *Store) persist() error {
+	list := make([]*Watch, 0, len(s.watches))
+	for _, w := range s.watches {
+		list = append(list, w)
+	}
+	data, err := json.Marshal(list)
+	if err != nil {
+		return fmt.Errorf("watch: marshal snapshot: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("watch: write snapshot: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("watch: rename snapshot: %w", err)
+	}
+	return nil
+}
+
+func newID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// Create assigns an ID, timestamps, and active status, then persists.
+func (s *Store) Create(ctx context.Context, w Watch) (Watch, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	w.ID = newID()
+	w.Status = StatusActive
+	w.CreatedAt = time.Now()
+
+	stored := w
+	s.watches[w.ID] = &stored
+	if err := s.persist(); err != nil {
+		delete(s.watches, w.ID)
+		return Watch{}, err
+	}
+	return stored, nil
+}
+
+// Get returns a copy of the watch, or ErrNotFound.
+func (s *Store) Get(ctx context.Context, id string) (Watch, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	w, ok := s.watches[id]
+	if !ok {
+		return Watch{}, ErrNotFound
+	}
+	return *w, nil
+}
+
+// Delete cancels a watch. It is idempotent: deleting an unknown or already
+// cancelled watch is a no-op success.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	w, ok := s.watches[id]
+	if !ok || w.Status == StatusCancelled {
+		return nil
+	}
+	w.Status = StatusCancelled
+	return s.persist()
+}
+
+// ListActive returns copies of every watch that is active and not yet expired.
+func (s *Store) ListActive(ctx context.Context) ([]Watch, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	now := time.Now()
+	var out []Watch
+	for _, w := range s.watches {
+		if w.Status == StatusActive && w.ExpiresAt.After(now) {
+			out = append(out, *w)
+		}
+	}
+	return out, nil
+}
+
+// Apply mutates a watch under the write lock, but only while it is still active.
+// fn returns whether it changed anything; Apply persists and reports changed.
+// A missing or non-active watch is a no-op (changed=false, nil error) so a
+// concurrent Delete can't be raced into a notification or resurrection.
+func (s *Store) Apply(ctx context.Context, id string, fn func(*Watch) bool) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	w, ok := s.watches[id]
+	if !ok || w.Status != StatusActive {
+		return false, nil
+	}
+	if !fn(w) {
+		return false, nil
+	}
+	if err := s.persist(); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -71,10 +71,12 @@ func (s *Store) persist() error {
 	return nil
 }
 
-func newID() string {
+func newID() (string, error) {
 	b := make([]byte, 12)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("watch: generate id: %w", err)
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // Create assigns an ID, timestamps, and active status, then persists.
@@ -82,7 +84,11 @@ func (s *Store) Create(ctx context.Context, w Watch) (Watch, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	w.ID = newID()
+	id, err := newID()
+	if err != nil {
+		return Watch{}, err
+	}
+	w.ID = id
 	w.Status = StatusActive
 	w.CreatedAt = time.Now()
 

--- a/internal/watch/store_apply_test.go
+++ b/internal/watch/store_apply_test.go
@@ -1,0 +1,115 @@
+package watch
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStore_ListActiveExcludesExpiredAndCancelled(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	active, _ := s.Create(ctx, sampleWatch())
+
+	expiredW := sampleWatch()
+	expiredW.ExpiresAt = time.Now().Add(-time.Hour)
+	expired, _ := s.Create(ctx, expiredW)
+
+	cancelled, _ := s.Create(ctx, sampleWatch())
+	if err := s.Delete(ctx, cancelled.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	list, err := s.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != active.ID {
+		t.Fatalf("expected only %s active, got %+v", active.ID, list)
+	}
+	_ = expired
+}
+
+func TestStore_DeleteIsIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	w, _ := s.Create(ctx, sampleWatch())
+
+	if err := s.Delete(ctx, w.ID); err != nil {
+		t.Fatalf("first Delete: %v", err)
+	}
+	if err := s.Delete(ctx, w.ID); err != nil {
+		t.Fatalf("second Delete should be a no-op, got: %v", err)
+	}
+	got, _ := s.Get(ctx, w.ID)
+	if got.Status != StatusCancelled {
+		t.Errorf("expected cancelled, got %q", got.Status)
+	}
+}
+
+func TestStore_ReloadFromSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	s1, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	created, _ := s1.Create(context.Background(), sampleWatch())
+
+	s2, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("reopen NewStore: %v", err)
+	}
+	got, err := s2.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("Get after reload: %v", err)
+	}
+	if got.ID != created.ID || got.HUnitID != created.HUnitID {
+		t.Errorf("reloaded watch mismatch: %+v", got)
+	}
+}
+
+func TestStore_ApplyMutatesActiveWatch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	w, _ := s.Create(ctx, sampleWatch())
+
+	d := "2026-07-01"
+	changed, err := s.Apply(ctx, w.ID, func(w *Watch) bool {
+		w.CurrentDate = &d
+		return true
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true")
+	}
+	got, _ := s.Get(ctx, w.ID)
+	if got.CurrentDate == nil || *got.CurrentDate != d {
+		t.Errorf("expected CurrentDate %q, got %v", d, got.CurrentDate)
+	}
+}
+
+func TestStore_ApplyIsNoOpOnCancelledWatch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	w, _ := s.Create(ctx, sampleWatch())
+	_ = s.Delete(ctx, w.ID)
+
+	called := false
+	changed, err := s.Apply(ctx, w.ID, func(w *Watch) bool {
+		called = true
+		return true
+	})
+	if err != nil {
+		t.Fatalf("Apply on cancelled should not error, got: %v", err)
+	}
+	if called {
+		t.Error("fn must not run on a cancelled watch")
+	}
+	if changed {
+		t.Error("expected changed=false for cancelled watch")
+	}
+}

--- a/internal/watch/store_test.go
+++ b/internal/watch/store_test.go
@@ -1,0 +1,62 @@
+package watch
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func sampleWatch() Watch {
+	pref := 5
+	return Watch{
+		HUnitID:      718,
+		SpecialtyID:  24,
+		ForeasID:     1,
+		PrefectureID: &pref,
+		ExpiresAt:    time.Now().Add(24 * time.Hour),
+	}
+}
+
+func TestStore_CreateAssignsIDAndActiveStatus(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	created, err := s.Create(ctx, sampleWatch())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ID == "" {
+		t.Error("expected a generated ID")
+	}
+	if created.Status != StatusActive {
+		t.Errorf("expected status %q, got %q", StatusActive, created.Status)
+	}
+	if created.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	got, err := s.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != created.ID || got.HUnitID != 718 || got.SpecialtyID != 24 {
+		t.Errorf("Get returned unexpected watch: %+v", got)
+	}
+}
+
+func TestStore_GetUnknownReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Get(context.Background(), "nope"); err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,47 @@
+// Package watch implements the cancellation watchdog (#5): a registry of
+// per-unit appointment watches, a background poller that re-checks the upstream
+// first-available date, and notifiers that alert the user when an earlier slot
+// appears.
+package watch
+
+import (
+	"errors"
+	"time"
+)
+
+// Status is the lifecycle state of a watch.
+type Status string
+
+const (
+	StatusActive    Status = "active"
+	StatusExpired   Status = "expired"
+	StatusCancelled Status = "cancelled"
+)
+
+// ErrNotFound is returned by the Store when a watch ID is unknown.
+var ErrNotFound = errors.New("watch: not found")
+
+// Watch is a single per-unit appointment watch.
+type Watch struct {
+	ID           string `json:"id"`
+	HUnitID      int    `json:"hunitId"`
+	SpecialtyID  int    `json:"specialtyId"`
+	ForeasID     int    `json:"foreasId"`
+	PrefectureID *int   `json:"prefectureId,omitempty"`
+
+	// CurrentDate is the latest observed first-available date (YYYY-MM-DD). It
+	// may move later (slots fill) or earlier (a cancellation). nil until the
+	// first successful observation.
+	CurrentDate *string `json:"currentDate,omitempty"`
+	// LastNotifiedDate is the earliest date the user has been successfully told
+	// about; it is the dedup + retry guard.
+	LastNotifiedDate *string `json:"lastNotifiedDate,omitempty"`
+
+	TelegramChatID *string `json:"telegramChatId,omitempty"`
+	WebhookURL     *string `json:"webhookUrl,omitempty"`
+
+	Status        Status    `json:"status"`
+	CreatedAt     time.Time `json:"createdAt"`
+	ExpiresAt     time.Time `json:"expiresAt"`
+	LastCheckedAt time.Time `json:"lastCheckedAt,omitempty"`
+}


### PR DESCRIPTION
Closes #5.

Implements the cancellation watchdog: register a watch on a unit + specialty, and a background poller pings you when an earlier first-available date shows up (usually because someone cancelled).

Design doc: `docs/superpowers/specs/2026-06-08-cancellation-watchdog-design.md` (brainstormed and reviewed by Codex before any code).

New package `internal/watch`, all TDD'd:
- **Store** — in-memory map + atomic JSON snapshot (temp + rename). Zero new deps; picked over SQLite/bbolt for the smallest footprint. Writes go through an `Apply` primitive that mutates a watch only while it's still active, so a concurrent `DELETE` can't be raced into a notification.
- **Notifiers** — Telegram (Bot API) and webhook, each skipping unconfigured channels.
- **Poller** — per-unit re-check with a seed/improvement/retry state model. `CurrentDate` tracks the latest observed date; `LastNotifiedDate` is the dedup + retry guard, so a failed notify re-fires next tick. The baseline is seeded at creation so a cancellation between create and first poll isn't swallowed.

API: `POST/GET/DELETE /api/watches`, wired in `main.go` with the poller on the signal context and a bounded drain on shutdown.

Config (all opt-in): `WATCH_STATE_PATH`, `WATCH_POLL_INTERVAL`, `TELEGRAM_BOT_TOKEN`. With no watches it does nothing; Telegram stays inert without a token.

CodeRabbit pass: SSRF guard on the webhook URL (reject loopback/private/metadata hosts), `DELETE` added to CORS, and the `crypto/rand` error in ID generation is now propagated.

Verified live in the browser: create/get/delete round-trip, the JSON error envelope on bad input, the persisted snapshot, and the Prometheus metrics. 24 new tests, race-clean, golangci-lint clean.
