### PR TITLE
nightshift: nightshift-pool-g7y (nightshift/nightshift-pool-g7y-a1)

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -1,0 +1,45 @@
+# RESULT
+
+## Task
+Fix `internal/aggregator` silently dropping units whose upstream record lacks
+geo coordinates (`Latitude==0 && Longitude==0`) when `SmartSearch` applies a
+`MaxDistance` filter. Add a `hasCoords` predicate, keep coordinate-less units in
+the results (sorted last), and add the missing tests.
+
+## Changes
+- `internal/aggregator/geo.go`
+  - Added `hasCoords(lat, lon float64) bool`. Returns `false` for 0/0 records
+    (the upstream default for a missing location) and for any `NaN` component;
+    `true` otherwise.
+- `internal/aggregator/search.go` (`SmartSearch`)
+  - Distance filter now keeps units without usable coordinates instead of
+    computing a bogus large distance and excluding them.
+  - Sort tie-breaker: units with an unknown location sort after units that can
+    be ranked by real distance (i.e. coordinate-less units go last).
+- `internal/aggregator/geo_test.go` (new)
+  - `TestDistance`: table test — Athens→Thessaloniki ≈ 300 km (±20),
+    identical points = 0.
+  - `TestHasCoords`: valid pair, 0/0, NaN lat, NaN lon, valid negative coords.
+- `internal/aggregator/search_test.go`
+  - Added subtest `Zero-Coordinate Unit Survives Restrictive MaxDistance`:
+    proves a 0/0 unit is retained under `MaxDistance: 10` and is sorted last.
+
+Functions modified by `feat/private-eopyy-slots` were not touched; only
+`SmartSearch` (explicitly noted safe) and geo helpers were changed.
+
+## Test output
+`go test ./...`
+```
+?   github.com/angelospk/find_doctors_server/cmd/server	[no test files]
+ok  github.com/angelospk/find_doctors_server/internal/aggregator	0.012s
+ok  github.com/angelospk/find_doctors_server/internal/api	0.023s
+ok  github.com/angelospk/find_doctors_server/internal/ministry	(cached)
+ok  github.com/angelospk/find_doctors_server/internal/watch	(cached)
+```
+`go vet ./internal/aggregator/` — clean.
+
+## Follow-ups
+- The `sort.Slice` comparator is not a strict weak ordering when `FirstDate` is
+  nil on both sides / one side (pre-existing behavior, unchanged here). If a
+  fully deterministic ordering is needed, consider `sort.SliceStable` with a
+  total-order comparator. Left as-is to stay within scope.

--- a/internal/aggregator/geo.go
+++ b/internal/aggregator/geo.go
@@ -13,3 +13,13 @@ func distance(lat1, lon1, lat2, lon2 float64) float64 {
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
 	return R * c
 }
+
+// hasCoords reports whether a lat/lon pair carries usable geographic data.
+// A 0/0 record (the upstream default for a missing location) and any NaN
+// component are treated as "unknown" rather than a real point off West Africa.
+func hasCoords(lat, lon float64) bool {
+	if math.IsNaN(lat) || math.IsNaN(lon) {
+		return false
+	}
+	return lat != 0 || lon != 0
+}

--- a/internal/aggregator/geo_test.go
+++ b/internal/aggregator/geo_test.go
@@ -1,0 +1,61 @@
+package aggregator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDistance(t *testing.T) {
+	tests := []struct {
+		name                   string
+		lat1, lon1, lat2, lon2 float64
+		want                   float64
+		tolerance              float64
+	}{
+		{
+			name: "Athens to Thessaloniki",
+			lat1: 37.9838, lon1: 23.7275, // Athens
+			lat2: 40.6401, lon2: 22.9444, // Thessaloniki
+			want:      300,
+			tolerance: 20,
+		},
+		{
+			name: "identical points",
+			lat1: 37.9838, lon1: 23.7275,
+			lat2: 37.9838, lon2: 23.7275,
+			want:      0,
+			tolerance: 0.001,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := distance(tt.lat1, tt.lon1, tt.lat2, tt.lon2)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("distance() = %.2f km, want %.2f ± %.2f km", got, tt.want, tt.tolerance)
+			}
+		})
+	}
+}
+
+func TestHasCoords(t *testing.T) {
+	tests := []struct {
+		name     string
+		lat, lon float64
+		want     bool
+	}{
+		{"valid Athens", 37.9838, 23.7275, true},
+		{"zero/zero is unknown", 0, 0, false},
+		{"NaN lat is unknown", math.NaN(), 23.7275, false},
+		{"NaN lon is unknown", 37.9838, math.NaN(), false},
+		{"valid negative", -33.8688, 151.2093, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCoords(tt.lat, tt.lon); got != tt.want {
+				t.Errorf("hasCoords(%v, %v) = %v, want %v", tt.lat, tt.lon, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/aggregator/search.go
+++ b/internal/aggregator/search.go
@@ -263,6 +263,13 @@ func (a *Aggregator) SmartSearch(ctx context.Context, units []ministry.HUnit, pa
 	var filtered []ScannedUnit
 	if opts.MaxDistance > 0 && opts.Lat != nil && opts.Lon != nil {
 		for _, u := range scanned {
+			// Units whose upstream record lacks usable coordinates have an
+			// unknown location, not a distant one — keep them rather than
+			// silently dropping valid results with a bogus 0/0 distance.
+			if !hasCoords(u.Latitude, u.Longitude) {
+				filtered = append(filtered, u)
+				continue
+			}
 			d := distance(*opts.Lat, *opts.Lon, u.Latitude, u.Longitude)
 			if d <= opts.MaxDistance {
 				filtered = append(filtered, u)
@@ -286,6 +293,15 @@ func (a *Aggregator) SmartSearch(ctx context.Context, units []ministry.HUnit, pa
 			return *filtered[i].FirstDate < *filtered[j].FirstDate
 		}
 		if opts.Lat != nil && opts.Lon != nil {
+			iHas := hasCoords(filtered[i].Latitude, filtered[i].Longitude)
+			jHas := hasCoords(filtered[j].Latitude, filtered[j].Longitude)
+			// Units with an unknown location sort after those we can rank by distance.
+			if iHas != jHas {
+				return iHas
+			}
+			if !iHas {
+				return false
+			}
 			distI := distance(*opts.Lat, *opts.Lon, filtered[i].Latitude, filtered[i].Longitude)
 			distJ := distance(*opts.Lat, *opts.Lon, filtered[j].Latitude, filtered[j].Longitude)
 			return distI < distJ

--- a/internal/aggregator/search_test.go
+++ b/internal/aggregator/search_test.go
@@ -269,6 +269,48 @@ func TestAggregator_SmartSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("Zero-Coordinate Unit Survives Restrictive MaxDistance", func(t *testing.T) {
+		h4 := 400
+		unitsWithMissing := []ministry.HUnit{
+			{HUnit: &h1, Name: "Close Soon", Latitude: 37.98, Longitude: 23.72, ForeasID: 1}, // ~0km
+			{HUnit: &h4, Name: "No Coords", Latitude: 0, Longitude: 0, ForeasID: 1},           // unknown location
+		}
+
+		missingClient := &MockMinistryClient{
+			FirstAvailableSlotFunc: func(ctx context.Context, payload ministry.SearchPayload) (string, error) {
+				return "2024-05-01", nil
+			},
+		}
+		aggMissing := New(missingClient)
+
+		lat, lon := 37.98, 23.72
+		opts := SmartSearchOptions{
+			Lat:         &lat,
+			Lon:         &lon,
+			MaxDistance: 10, // Restrictive: would exclude a huge-distance 0/0 computation
+		}
+		results := aggMissing.SmartSearch(ctx, unitsWithMissing, ministry.SearchPayload{}, opts)
+
+		if len(results) != 2 {
+			t.Fatalf("Expected 2 results (unit with missing coords must survive), got %d", len(results))
+		}
+
+		var foundNoCoords bool
+		for _, r := range results {
+			if r.Name == "No Coords" {
+				foundNoCoords = true
+			}
+		}
+		if !foundNoCoords {
+			t.Errorf("Expected zero-coordinate unit to survive restrictive MaxDistance, but it was dropped")
+		}
+
+		// The unit without usable coordinates should be sorted last.
+		if results[len(results)-1].Name != "No Coords" {
+			t.Errorf("Expected zero-coordinate unit sorted last, got %s", results[len(results)-1].Name)
+		}
+	})
+
 	t.Run("Multi-Level Sorting", func(t *testing.T) {
 		lat, lon := 37.98, 23.72
 		opts := SmartSearchOptions{


### PR DESCRIPTION
Opened by nightshift for `nightshift-pool-g7y` — branch `nightshift/nightshift-pool-g7y-a1` at `a84eb90d12d8ee3d394fd4076e71ddf6ec0fc5ae`.
Draft on purpose: review before marking ready.

---

# RESULT

## Task
Fix `internal/aggregator` silently dropping units whose upstream record lacks
geo coordinates (`Latitude==0 && Longitude==0`) when `SmartSearch` applies a
`MaxDistance` filter. Add a `hasCoords` predicate, keep coordinate-less units in
the results (sorted last), and add the missing tests.

## Changes
- `internal/aggregator/geo.go`
  - Added `hasCoords(lat, lon float64) bool`. Returns `false` for 0/0 records
    (the upstream default for a missing location) and for any `NaN` component;
    `true` otherwise.
- `internal/aggregator/search.go` (`SmartSearch`)
  - Distance filter now keeps units without usable coordinates instead of
    computing a bogus large distance and excluding them.
  - Sort tie-breaker: units with an unknown location sort after units that can
    be ranked by real distance (i.e. coordinate-less units go last).
- `internal/aggregator/geo_test.go` (new)
  - `TestDistance`: table test — Athens→Thessaloniki ≈ 300 km (±20),
    identical points = 0.
  - `TestHasCoords`: valid pair, 0/0, NaN lat, NaN lon, valid negative coords.
- `internal/aggregator/search_test.go`
  - Added subtest `Zero-Coordinate Unit Survives Restrictive MaxDistance`:
    proves a 0/0 unit is retained under `MaxDistance: 10` and is sorted last.

Functions modified by `feat/private-eopyy-slots` were not touched; only
`SmartSearch` (explicitly noted safe) and geo helpers were changed.

## Test output
`go test ./...`
```
?   github.com/angelospk/find_doctors_server/cmd/server	[no test files]
ok  github.com/angelospk/find_doctors_server/internal/aggregator	0.012s
ok  github.com/angelospk/find_doctors_server/internal/api	0.023s
ok  github.com/angelospk/find_doctors_server/internal/ministry	(cached)
ok  github.com/angelospk/find_doctors_server/internal/watch	(cached)
```
`go vet ./internal/aggregator/` — clean.

## Follow-ups
- The `sort.Slice` comparator is not a strict weak ordering when `FirstDate` is
  nil on both sides / one side (pre-existing behavior, unchanged here). If a
  fully deterministic ordering is needed, consider `sort.SliceStable` with a
  total-order comparator. Left as-is to stay within scope.
