### PR TITLE
nightshift: nightshift-pool-bmk (nightshift/nightshift-pool-bmk-a1)

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -1,0 +1,52 @@
+# RESULT
+
+## Task
+Make the ministry client retry on HTTP 429 (Too Many Requests) and honor the
+`Retry-After` header, so upstream rate-limiting backs off instead of aborting
+the whole scan on the first throttle.
+
+## Changes
+
+### `internal/ministry/client.go`
+- Added `http.StatusTooManyRequests` (429) to `retryableStatus`, so 429 is now
+  treated as a transient failure worth retrying instead of falling through to
+  the `unexpected status code` error.
+- Added `parseRetryAfter(v string, now time.Time) (time.Duration, bool)`, which
+  parses a `Retry-After` header in either form: delta-seconds (integer) or
+  HTTP-date (`http.ParseTime`). Negative/past or unparseable values return
+  `ok=false` so the caller falls back to the existing jittered backoff.
+- Added `maxRetryAfter = 30s` constant to cap an upstream-supplied delay so a
+  misbehaving server can't stall a fan-out scan for minutes.
+- In `doJSON`'s retry loop: when a 429 response carries a usable `Retry-After`,
+  that delay (capped at `maxRetryAfter`) is used for the next attempt's wait;
+  otherwise the existing jittered exponential backoff is used unchanged. Other
+  retryable statuses (500/502/503/504) and network errors keep the jittered
+  backoff.
+- New imports: `strconv`, `strings`.
+
+### `internal/ministry/client_test.go`
+- Added `TestClient_Retry429`, a table test using an `httptest.Server` that
+  returns 429 on the first call then 200. Cases:
+  - **without Retry-After** — retries via fast jittered backoff, succeeds
+    (asserts elapsed <= 500ms with `RetryWait` set to 10ms).
+  - **with Retry-After delta-seconds** (`Retry-After: 1`) — asserts the retry
+    waited >= 1s.
+  - **with Retry-After HTTP-date** (2s in the future) — asserts the retry
+    waited >= 900ms.
+  Each case asserts exactly 2 upstream calls (1 retry) and a successful decode.
+
+## Test output
+`go test ./...`:
+```
+?   github.com/angelospk/find_doctors_server/cmd/server	[no test files]
+ok  github.com/angelospk/find_doctors_server/internal/aggregator	0.014s
+ok  github.com/angelospk/find_doctors_server/internal/api	0.024s
+ok  github.com/angelospk/find_doctors_server/internal/ministry	2.869s
+ok  github.com/angelospk/find_doctors_server/internal/watch	0.020s
+```
+`go vet ./internal/ministry/` clean; `gofmt -l` reports no changes.
+
+## Follow-ups
+- None required. Possible future nicety: honor `Retry-After` on non-429
+  retryable statuses too (some servers send it on 503), but the spec scoped
+  this to 429 so it was left as-is.

--- a/internal/ministry/client.go
+++ b/internal/ministry/client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -86,12 +88,44 @@ func (c *Client) setStdHeaders(req *http.Request) {
 }
 
 // retryableStatus reports whether an HTTP status code is worth retrying.
+// 429 (Too Many Requests) is included so upstream rate-limiting backs off
+// instead of aborting the whole scan on the first throttle.
 func retryableStatus(code int) bool {
 	switch code {
-	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusInternalServerError:
+	case http.StatusTooManyRequests,
+		http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusInternalServerError:
 		return true
 	}
 	return false
+}
+
+// maxRetryAfter caps how long we honor an upstream Retry-After hint. A
+// misbehaving server advertising minutes must not stall a fan-out scan.
+const maxRetryAfter = 30 * time.Second
+
+// parseRetryAfter interprets a Retry-After header value, which may be either
+// delta-seconds (an integer) or an HTTP-date. It returns the delay to wait and
+// whether the value was understood. Negative/past or unparseable values return
+// ok=false so the caller falls back to the jittered backoff.
+func parseRetryAfter(v string, now time.Time) (time.Duration, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		d := t.Sub(now)
+		if d < 0 {
+			d = 0
+		}
+		return d, true
+	}
+	return 0, false
 }
 
 // endpointLabel collapses a full URL to a short label suitable for metrics
@@ -142,6 +176,10 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any, out a
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		// retryAfter holds an upstream-supplied delay (from a 429 Retry-After
+		// header) to honor instead of the jittered backoff this attempt.
+		var retryAfter time.Duration
+		var useRetryAfter bool
 		start := time.Now()
 
 		var rdr io.Reader
@@ -180,6 +218,11 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any, out a
 				}
 				return nil
 			}
+			if res.StatusCode == http.StatusTooManyRequests {
+				if d, ok := parseRetryAfter(res.Header.Get("Retry-After"), time.Now()); ok {
+					retryAfter, useRetryAfter = d, true
+				}
+			}
 			// Drain & close so the connection can be reused.
 			_, _ = io.Copy(io.Discard, res.Body)
 			_ = res.Body.Close()
@@ -193,11 +236,21 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any, out a
 		// Backoff before next attempt (unless this was the last).
 		if attempt < max-1 {
 			apiRetries.WithLabelValues(endpoint).Inc()
-			// Jittered backoff: base ± 25% so concurrent clients don't
-			// retry in lockstep against a recovering upstream.
-			base := wait * time.Duration(1<<attempt)
-			jitter := time.Duration(rand.Int63n(int64(base)/2 + 1))
-			delay := base - base/4 + jitter
+			var delay time.Duration
+			if useRetryAfter {
+				// Honor the upstream's own pacing hint, capped so a bad
+				// value can't stall the scan.
+				delay = retryAfter
+				if delay > maxRetryAfter {
+					delay = maxRetryAfter
+				}
+			} else {
+				// Jittered backoff: base ± 25% so concurrent clients don't
+				// retry in lockstep against a recovering upstream.
+				base := wait * time.Duration(1<<attempt)
+				jitter := time.Duration(rand.Int63n(int64(base)/2 + 1))
+				delay = base - base/4 + jitter
+			}
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/internal/ministry/client_test.go
+++ b/internal/ministry/client_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestClient_SearchHUnits(t *testing.T) {
@@ -161,6 +163,78 @@ func TestClient_GetSlotsInit_Success(t *testing.T) {
 	}
 	if groups[1].GroupColor != "disabled" {
 		t.Errorf("Expected 'disabled', got '%s'", groups[1].GroupColor)
+	}
+}
+
+func TestClient_Retry429(t *testing.T) {
+	tests := []struct {
+		name       string
+		setHeader  func(w http.ResponseWriter)
+		minElapsed time.Duration
+		maxElapsed time.Duration // 0 = no upper bound check
+	}{
+		{
+			name:       "without Retry-After uses jittered backoff",
+			setHeader:  nil,
+			minElapsed: 0,
+			maxElapsed: 500 * time.Millisecond,
+		},
+		{
+			name: "with Retry-After delta-seconds",
+			setHeader: func(w http.ResponseWriter) {
+				w.Header().Set("Retry-After", "1")
+			},
+			minElapsed: time.Second,
+		},
+		{
+			name: "with Retry-After HTTP-date",
+			setHeader: func(w http.ResponseWriter) {
+				w.Header().Set("Retry-After", time.Now().Add(2*time.Second).UTC().Format(http.TimeFormat))
+			},
+			minElapsed: 900 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int32
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if n := atomic.AddInt32(&calls, 1); n == 1 {
+					if tt.setHeader != nil {
+						tt.setHeader(w)
+					}
+					w.WriteHeader(http.StatusTooManyRequests)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`[{"groupColor": "warning", "groupTitle": "Available"}]`))
+			}))
+			defer mockServer.Close()
+
+			client := NewClient(mockServer.URL)
+			// Keep the jittered fallback backoff tiny so the no-header case is fast.
+			client.RetryWait = 10 * time.Millisecond
+
+			start := time.Now()
+			groups, err := client.GetSlotsInit(context.Background(), SlotsInitPayload{})
+			elapsed := time.Since(start)
+
+			if err != nil {
+				t.Fatalf("expected success after retry, got %v", err)
+			}
+			if len(groups) != 1 {
+				t.Fatalf("expected 1 group, got %d", len(groups))
+			}
+			if got := atomic.LoadInt32(&calls); got != 2 {
+				t.Fatalf("expected 2 upstream calls (1 retry), got %d", got)
+			}
+			if elapsed < tt.minElapsed {
+				t.Fatalf("expected delay >= %v (Retry-After respected), got %v", tt.minElapsed, elapsed)
+			}
+			if tt.maxElapsed > 0 && elapsed > tt.maxElapsed {
+				t.Fatalf("expected fast jittered backoff <= %v, got %v", tt.maxElapsed, elapsed)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Opened by nightshift for `nightshift-pool-bmk` — branch `nightshift/nightshift-pool-bmk-a1` at `99d27b69ca62954b1349381611ea4beb08f9e4e9`.
Draft on purpose: review before marking ready.

---

# RESULT

## Task
Make the ministry client retry on HTTP 429 (Too Many Requests) and honor the
`Retry-After` header, so upstream rate-limiting backs off instead of aborting
the whole scan on the first throttle.

## Changes

### `internal/ministry/client.go`
- Added `http.StatusTooManyRequests` (429) to `retryableStatus`, so 429 is now
  treated as a transient failure worth retrying instead of falling through to
  the `unexpected status code` error.
- Added `parseRetryAfter(v string, now time.Time) (time.Duration, bool)`, which
  parses a `Retry-After` header in either form: delta-seconds (integer) or
  HTTP-date (`http.ParseTime`). Negative/past or unparseable values return
  `ok=false` so the caller falls back to the existing jittered backoff.
- Added `maxRetryAfter = 30s` constant to cap an upstream-supplied delay so a
  misbehaving server can't stall a fan-out scan for minutes.
- In `doJSON`'s retry loop: when a 429 response carries a usable `Retry-After`,
  that delay (capped at `maxRetryAfter`) is used for the next attempt's wait;
  otherwise the existing jittered exponential backoff is used unchanged. Other
  retryable statuses (500/502/503/504) and network errors keep the jittered
  backoff.
- New imports: `strconv`, `strings`.

### `internal/ministry/client_test.go`
- Added `TestClient_Retry429`, a table test using an `httptest.Server` that
  returns 429 on the first call then 200. Cases:
  - **without Retry-After** — retries via fast jittered backoff, succeeds
    (asserts elapsed <= 500ms with `RetryWait` set to 10ms).
  - **with Retry-After delta-seconds** (`Retry-After: 1`) — asserts the retry
    waited >= 1s.
  - **with Retry-After HTTP-date** (2s in the future) — asserts the retry
    waited >= 900ms.
  Each case asserts exactly 2 upstream calls (1 retry) and a successful decode.

## Test output
`go test ./...`:
```
?   github.com/angelospk/find_doctors_server/cmd/server	[no test files]
ok  github.com/angelospk/find_doctors_server/internal/aggregator	0.014s
ok  github.com/angelospk/find_doctors_server/internal/api	0.024s
ok  github.com/angelospk/find_doctors_server/internal/ministry	2.869s
ok  github.com/angelospk/find_doctors_server/internal/watch	0.020s
```
`go vet ./internal/ministry/` clean; `gofmt -l` reports no changes.

## Follow-ups
- None required. Possible future nicety: honor `Retry-After` on non-429
  retryable statuses too (some servers send it on 503), but the spec scoped
  this to 429 so it was left as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retries for temporary “429 Too Many Requests” responses.
  * Honors valid `Retry-After` headers using either delay-seconds or HTTP-date formats.
  * Caps retry delays at 30 seconds and falls back to the existing retry behavior when no valid guidance is provided.

* **Documentation**
  * Added documentation covering retry behavior, validation, and test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->