### PR TITLE
nightshift: nightshift-pool-jqq (nightshift/nightshift-pool-jqq-a1)

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -1,0 +1,52 @@
+# RESULT — focused table test for `computeFillRate`
+
+## What changed
+
+- **Added** `internal/aggregator/fill_rate_test.go` (test-only, new file).
+
+No production code was touched — `git status` shows only the new test file.
+
+The new `TestComputeFillRate` is a table test calling the pure function directly
+(previously the rule was only covered indirectly via `HospitalCapacity` with a
+mocked ministry client). Cases:
+
+1. **Fully-disabled day excluded from denominator** — day 1 all `disabled`, day 2
+   one of two disabled → 50%, `ScheduleDays=[2]`, `ActiveGroups=2`.
+2. **Mixed enabled/disabled** — 2 disabled out of 4 active groups over days 1 and 3 → 50%.
+3. **Empty `GroupColor` skipped** — colorless groups don't count toward totals, and a
+   day made up only of colorless groups never enters `ScheduleDays` at all.
+4. **`activeGroups == 0`** — all days fully disabled / colorless → `FillRate = 0.0`,
+   empty `ScheduleDays`, no divide-by-zero.
+5. **No groups at all** — same zero-valued result.
+6. **`ScheduleDays` sorted and deduped** — days 5,1,5,3,1,3 → `[1,3,5]`, fill rate 1/6.
+
+Each case also asserts `ActiveGroups`/`DisabledSlots` and that the passed-in row's
+identity fields (`ID`, `Name`) survive untouched.
+
+## TDD note
+
+The spec is test-only for behavior that already exists, so there is no red→green
+implementation step. Instead I verified the test actually constrains the rule by
+temporarily deleting the `if s.disabled == s.total { continue }` guard in
+`computeFillRate` and re-running: cases 1 and 4 failed (`FillRate = 75, want 50`;
+`FillRate = 100, want 0`). The guard was then restored — confirmed clean via
+`git status` and a passing suite.
+
+## Test output
+
+```
+$ go test ./...
+?   	github.com/angelospk/find_doctors_server/cmd/server	[no test files]
+ok  	github.com/angelospk/find_doctors_server/internal/aggregator	0.006s
+ok  	github.com/angelospk/find_doctors_server/internal/api	(cached)
+ok  	github.com/angelospk/find_doctors_server/internal/ministry	(cached)
+ok  	github.com/angelospk/find_doctors_server/internal/watch	(cached)
+```
+
+## Follow-ups (not done, out of scope)
+
+- `HospitalCapacity` short-circuits on `len(groups) == 1 && groups[0].ResponseCode == 2`
+  before ever calling `computeFillRate`; that branch stays covered only at the
+  `HospitalCapacity` level.
+- `computeFillRate` ignores `ResponseCode` entirely — if a non-zero response code is ever
+  meant to invalidate a group, that rule currently has no home in the pure function.

--- a/internal/aggregator/fill_rate_test.go
+++ b/internal/aggregator/fill_rate_test.go
@@ -1,0 +1,130 @@
+package aggregator
+
+import (
+	"math"
+	"testing"
+
+	"github.com/angelospk/find_doctors_server/internal/ministry"
+)
+
+// TestComputeFillRate exercises the pure fill-rate function directly, so the
+// "fully-disabled days are excluded from the denominator" rule is pinned down
+// without going through HospitalCapacity and its mocked client.
+func TestComputeFillRate(t *testing.T) {
+	tests := []struct {
+		name         string
+		groups       []ministry.SlotGroup
+		wantFillRate float64
+		wantDays     []int
+		wantActive   int
+		wantDisabled int
+	}{
+		{
+			name: "fully disabled day excluded from denominator",
+			groups: []ministry.SlotGroup{
+				// Day 1 is entirely off — must not count at all.
+				{Day: 1, GroupColor: "disabled"},
+				{Day: 1, GroupColor: "disabled"},
+				// Day 2 has one of two groups disabled.
+				{Day: 2, GroupColor: "disabled"},
+				{Day: 2, GroupColor: "green"},
+			},
+			wantFillRate: 50.0,
+			wantDays:     []int{2},
+			wantActive:   2,
+			wantDisabled: 1,
+		},
+		{
+			name: "mixed enabled and disabled across active days",
+			groups: []ministry.SlotGroup{
+				{Day: 1, GroupColor: "green"},
+				{Day: 1, GroupColor: "disabled"},
+				{Day: 1, GroupColor: "disabled"},
+				{Day: 3, GroupColor: "green"},
+			},
+			wantFillRate: 50.0, // 2 disabled out of 4 active groups
+			wantDays:     []int{1, 3},
+			wantActive:   4,
+			wantDisabled: 2,
+		},
+		{
+			name: "groups with empty GroupColor are skipped",
+			groups: []ministry.SlotGroup{
+				{Day: 1, GroupColor: ""},
+				{Day: 1, GroupColor: ""},
+				{Day: 1, GroupColor: "disabled"},
+				{Day: 1, GroupColor: "green"},
+				// Day 5 only has colorless groups — it never becomes a day at all.
+				{Day: 5, GroupColor: ""},
+			},
+			wantFillRate: 50.0,
+			wantDays:     []int{1},
+			wantActive:   2,
+			wantDisabled: 1,
+		},
+		{
+			name: "no active groups yields zero percent without dividing by zero",
+			groups: []ministry.SlotGroup{
+				{Day: 1, GroupColor: "disabled"},
+				{Day: 2, GroupColor: "disabled"},
+				{Day: 3, GroupColor: ""},
+			},
+			wantFillRate: 0.0,
+			wantDays:     []int{},
+			wantActive:   0,
+			wantDisabled: 0,
+		},
+		{
+			name:         "no groups at all yields zero percent",
+			groups:       []ministry.SlotGroup{},
+			wantFillRate: 0.0,
+			wantDays:     []int{},
+			wantActive:   0,
+			wantDisabled: 0,
+		},
+		{
+			name: "schedule days are sorted and deduped",
+			groups: []ministry.SlotGroup{
+				{Day: 5, GroupColor: "green"},
+				{Day: 1, GroupColor: "green"},
+				{Day: 5, GroupColor: "disabled"},
+				{Day: 3, GroupColor: "green"},
+				{Day: 1, GroupColor: "green"},
+				{Day: 3, GroupColor: "green"},
+			},
+			wantFillRate: 100.0 / 6.0, // 1 disabled out of 6 active groups
+			wantDays:     []int{1, 3, 5},
+			wantActive:   6,
+			wantDisabled: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeFillRate(SpecialtyCapacity{ID: 6, Name: "Dermatologist"}, tt.groups)
+
+			if math.Abs(got.FillRate-tt.wantFillRate) > 1e-9 {
+				t.Errorf("FillRate = %v, want %v", got.FillRate, tt.wantFillRate)
+			}
+			if got.ActiveGroups != tt.wantActive {
+				t.Errorf("ActiveGroups = %d, want %d", got.ActiveGroups, tt.wantActive)
+			}
+			if got.DisabledSlots != tt.wantDisabled {
+				t.Errorf("DisabledSlots = %d, want %d", got.DisabledSlots, tt.wantDisabled)
+			}
+			if len(got.ScheduleDays) != len(tt.wantDays) {
+				t.Fatalf("ScheduleDays = %v, want %v", got.ScheduleDays, tt.wantDays)
+			}
+			for i := range tt.wantDays {
+				if got.ScheduleDays[i] != tt.wantDays[i] {
+					t.Fatalf("ScheduleDays = %v, want %v", got.ScheduleDays, tt.wantDays)
+				}
+			}
+
+			// Identity fields must survive untouched.
+			if got.ID != 6 || got.Name != "Dermatologist" {
+				t.Errorf("row identity mutated: %+v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Opened by nightshift for `nightshift-pool-jqq` — branch `nightshift/nightshift-pool-jqq-a1` at `a01a78f20161c1c735fb153362561be3c06abc0b`.
Draft on purpose: review before marking ready.

---

# RESULT — focused table test for `computeFillRate`

## What changed

- **Added** `internal/aggregator/fill_rate_test.go` (test-only, new file).

No production code was touched — `git status` shows only the new test file.

The new `TestComputeFillRate` is a table test calling the pure function directly
(previously the rule was only covered indirectly via `HospitalCapacity` with a
mocked ministry client). Cases:

1. **Fully-disabled day excluded from denominator** — day 1 all `disabled`, day 2
   one of two disabled → 50%, `ScheduleDays=[2]`, `ActiveGroups=2`.
2. **Mixed enabled/disabled** — 2 disabled out of 4 active groups over days 1 and 3 → 50%.
3. **Empty `GroupColor` skipped** — colorless groups don't count toward totals, and a
   day made up only of colorless groups never enters `ScheduleDays` at all.
4. **`activeGroups == 0`** — all days fully disabled / colorless → `FillRate = 0.0`,
   empty `ScheduleDays`, no divide-by-zero.
5. **No groups at all** — same zero-valued result.
6. **`ScheduleDays` sorted and deduped** — days 5,1,5,3,1,3 → `[1,3,5]`, fill rate 1/6.

Each case also asserts `ActiveGroups`/`DisabledSlots` and that the passed-in row's
identity fields (`ID`, `Name`) survive untouched.

## TDD note

The spec is test-only for behavior that already exists, so there is no red→green
implementation step. Instead I verified the test actually constrains the rule by
temporarily deleting the `if s.disabled == s.total { continue }` guard in
`computeFillRate` and re-running: cases 1 and 4 failed (`FillRate = 75, want 50`;
`FillRate = 100, want 0`). The guard was then restored — confirmed clean via
`git status` and a passing suite.

## Test output

```
$ go test ./...
?   	github.com/angelospk/find_doctors_server/cmd/server	[no test files]
ok  	github.com/angelospk/find_doctors_server/internal/aggregator	0.006s
ok  	github.com/angelospk/find_doctors_server/internal/api	(cached)
ok  	github.com/angelospk/find_doctors_server/internal/ministry	(cached)
ok  	github.com/angelospk/find_doctors_server/internal/watch	(cached)
```

## Follow-ups (not done, out of scope)

- `HospitalCapacity` short-circuits on `len(groups) == 1 && groups[0].ResponseCode == 2`
  before ever calling `computeFillRate`; that branch stays covered only at the
  `HospitalCapacity` level.
- `computeFillRate` ignores `ResponseCode` entirely — if a non-zero response code is ever
  meant to invalidate a group, that rule currently has no home in the pure function.
